### PR TITLE
Fix envelope fill from zero line

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,8 +761,8 @@ function updateChart(chart,x,y,label,scatter,reactions){
         const dmin=x.map((v,i)=>({x:v,y:y[0][i]}));
         const dmax=x.map((v,i)=>({x:v,y:y[1][i]}));
         datasets=[
-            {label:label+' min',data:dmin,fill:'+1',borderColor:'blue',backgroundColor:'rgba(0,0,255,0.2)',showLine:true},
-            {label:label+' max',data:dmax,fill:'-1',borderColor:'green',backgroundColor:'rgba(0,255,0,0.2)',showLine:true}
+            {label:label+' min',data:dmin,fill:true,borderColor:'blue',backgroundColor:'rgba(0,0,255,0.2)',showLine:true},
+            {label:label+' max',data:dmax,fill:true,borderColor:'green',backgroundColor:'rgba(0,255,0,0.2)',showLine:true}
         ];
     } else {
         const xyData=x.map((v,i)=>({x:v,y:y[i]}));


### PR DESCRIPTION
## Summary
- ensure envelope charts fill from the beam's zero line rather than between bounds

## Testing
- `node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_685513fd6e4083208b7b548e662502c1