### PR TITLE
Fix broken buttons by removing DOMContentLoaded wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,6 @@
     <script src="solver.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" defer></script>
     <script>
-document.addEventListener('DOMContentLoaded', () => {
 // State
 const state = {
     spans: [],
@@ -943,7 +942,6 @@ function showTab(name){
 addSpan(10);
 addLineLoad(5000,0,10);
 solveSelected();
-});
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the `DOMContentLoaded` wrapper so functions remain in global scope

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68568afdbff8832086464a72503d4224