### PR TITLE
Fix stack overflow in computeSectionDesign export

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -275,5 +275,5 @@ if (typeof window !== 'undefined') {
     window.computeDiagrams = computeDiagrams;
     window.setCrossSections = setCrossSections;
     window.getSelfWeightLineLoads = (spans,name)=>getSelfWeightLineLoads(spans,name);
-    window.computeSectionDesign = (name,opts)=>computeSectionDesign(name,opts);
+    window.computeSectionDesign = computeSectionDesign;
 }


### PR DESCRIPTION
## Summary
- expose `computeSectionDesign` directly instead of via recursive wrapper

## Testing
- `node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_6856a2e386508320b89d6de6421d6a68