### PR TITLE
Improve design section outputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,8 +958,8 @@ function updateDesignEquations(design){
     if(!design){ div.innerHTML=''; if(window.MathJax) MathJax.typesetPromise([div]); return; }
     const mRd=(design.MRd/1000).toFixed(1);
     const vRd=(design.VRd/1000).toFixed(1);
-    div.innerHTML=`$$M_{Rd}=\\frac{W f_y}{\\gamma_{M0}}=${mRd}\\ \text{ kN\\,m}$$<br>`+
-                 `$$V_{Rd}=\\frac{A_v f_y}{\\sqrt{3}\\,\\gamma_{M0}}=${vRd}\\ \text{ kN}$$`;
+    div.innerHTML=`$$M_{Rd}=\\frac{W f_y}{\\gamma_{M0}}=${mRd}\\ \\mathrm{kN\\,m}$$<br>`+
+                 `$$V_{Rd}=\\frac{A_v f_y}{\\sqrt{3}\\,\\gamma_{M0}}=${vRd}\\ \\mathrm{kN}$$`;
     if(window.MathJax) MathJax.typesetPromise([div]);
 }
 
@@ -985,17 +985,25 @@ function updateDesignProps(name){
         if(state.envelopeForces){
             const mAbs=Math.max(Math.abs(state.envelopeForces.minMoment), Math.abs(state.envelopeForces.maxMoment));
             const vAbs=Math.max(Math.abs(state.envelopeForces.minShear), Math.abs(state.envelopeForces.maxShear));
-            if(Mutil) Mutil.textContent=(100*mAbs/design.MRd).toFixed(1)+'%';
-            if(Vutil) Vutil.textContent=(100*vAbs/design.VRd).toFixed(1)+'%';
+            if(Mutil){
+                const val=(100*mAbs/design.MRd);
+                Mutil.textContent=val.toFixed(1)+'%';
+                Mutil.style.color=val<=100?'green':'red';
+            }
+            if(Vutil){
+                const val=(100*vAbs/design.VRd);
+                Vutil.textContent=val.toFixed(1)+'%';
+                Vutil.style.color=val<=100?'green':'red';
+            }
         } else {
-            if(Mutil) Mutil.textContent='-';
-            if(Vutil) Vutil.textContent='-';
+            if(Mutil){ Mutil.textContent='-'; Mutil.style.color=''; }
+            if(Vutil){ Vutil.textContent='-'; Vutil.style.color=''; }
         }
     } else {
         MRdel.textContent='-';
         VRdel.textContent='-';
-        if(Mutil) Mutil.textContent='-';
-        if(Vutil) Vutil.textContent='-';
+        if(Mutil){ Mutil.textContent='-'; Mutil.style.color=''; }
+        if(Vutil){ Vutil.textContent='-'; Vutil.style.color=''; }
         updateDesignEquations(null);
     }
 }
@@ -1010,6 +1018,8 @@ function showTab(name){
 
 addSpan(10);
 addLineLoad(5000,0,10);
+addCombination('Comb1','SW:1.35,LC1:1.50');
+addCombination('Comb2','SW:0.90,LC1:1.50');
 solveSelected();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- show design utilization in green when below 100% and red otherwise
- fix LaTeX rendering of design equations and remove stray `ext`
- add default load combinations Comb1 and Comb2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e775a470832093dde856cdd71b87