### PR TITLE
Fix lint rules and add strict lint script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,8 @@
     "ecmaVersion": 2020,
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "no-use-before-define": "error",
+    "no-undef": "error"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "test": "node test/test.js",
     "lint": "eslint .",
-    "test:integration": "node test/integration.js"
+    "test:integration": "node test/integration.js",
+    "lint:strict": "eslint ."
   },
   "devDependencies": {
     "eslint": "^8.56.0"


### PR DESCRIPTION
## Summary
- enforce `no-use-before-define` and `no-undef`
- add `lint:strict` npm script so the repository instructions work

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`


------
https://chatgpt.com/codex/tasks/task_e_685a7a8f980c8320bc28888e875875f5