### PR TITLE
Fix NaN in LBA checks

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -133,7 +133,7 @@ function computeSectionDesign(name, opts){
         const MRd = fm*W/gammaM;
         const VRd = fv*Av/gammaM;
         let MRdLBA = MRd;
-        if(opts.unbracedLength){
+        if(typeof opts.unbracedLength === 'number' && opts.unbracedLength > 0){
             const Lb = opts.unbracedLength;
             const b = cs.b_mm/1000;
             const hsec = cs.h_mm/1000;
@@ -155,7 +155,7 @@ function computeSectionDesign(name, opts){
     const Av = hw*tw;
     const VRd = Av*fy/(Math.sqrt(3)*gammaM0);
     let MRdLBA = MRd;
-    if(opts.unbracedLength){
+    if(typeof opts.unbracedLength === 'number' && opts.unbracedLength > 0){
         const Lb = opts.unbracedLength;
         const b = cs.b_mm/1000;
         const It = ((2*b*Math.pow(tf,3))/3 + (hw*Math.pow(tw,3))/3);


### PR DESCRIPTION
## Summary
- guard against invalid bracing length in `computeSectionDesign`

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685d3bccc8f88320bfb8732a91b7d34c