### PR TITLE
Fix LaTeX escaping

### DIFF
--- a/index.html
+++ b/index.html
@@ -1179,9 +1179,9 @@ function updateDesignEquations(design){
     const mRdLBA=(design.MRdLBA/1000).toFixed(1);
     const vRd=(design.VRd/1000).toFixed(1);
     if(design.material==='timber'){
-        div.innerHTML=`$$M_{Rd}=\\frac{W f_{m,k}}{\\gamma_M}=${disp(mRd)}\\,\mathrm{kN\\,m}$$<br>`+
-                     `$$M_{Rd,LBA}=k_{crit} W f_{m,d}=${disp(mRdLBA)}\\,\mathrm{kN\\,m}$$<br>`+
-                     `$$V_{Rd}=\\frac{A_v f_{v,k}}{\\gamma_M}=${disp(vRd)}\\,\mathrm{kN}$$`;
+        div.innerHTML=String.raw`$$M_{Rd}=\frac{W f_{m,k}}{\gamma_M}=${disp(mRd)}\,\mathrm{kN\,m}$$<br>`+
+                     String.raw`$$M_{Rd,LBA}=k_{crit} W f_{m,d}=${disp(mRdLBA)}\,\mathrm{kN\,m}$$<br>`+
+                     String.raw`$$V_{Rd}=\frac{A_v f_{v,k}}{\gamma_M}=${disp(vRd)}\,\mathrm{kN}$$`;
     } else {
         const iw=design.Iw!==undefined?design.Iw.toExponential(2):'-';
         const it=design.It!==undefined?design.It.toExponential(2):'-';
@@ -1195,13 +1195,13 @@ function updateDesignEquations(design){
         const kw=design.kw!==undefined?design.kw.toFixed(2):'-';
         const mcr=design.Mcr!==undefined?(design.Mcr/1000).toFixed(1):'-';
         const chi=design.chiLT!==undefined?design.chiLT.toFixed(3):'-';
-        div.innerHTML=`$$M_{Rd}=\\frac{W f_y}{\\gamma_{M0}}=${disp(mRd)}\\,\mathrm{kN\\,m}$$<br>`+
-                     `$$M_{Rd,LBA}=\\chi_{LT} \\frac{W f_y}{\\gamma_{M0}}=${disp(mRdLBA)}\\,\mathrm{kN\\,m}$$<br>`+
-                     `$$V_{Rd}=\\frac{A_v f_y}{\\sqrt{3}\\,\\gamma_{M0}}=${disp(vRd)}\\,\mathrm{kN}$$<br>`+
-                     `$$I_z=${disp(iz)}\\,\mathrm{m^4},\ I_t=${disp(it)}\\,\mathrm{m^4},\ I_w=${disp(iw)}\\,\mathrm{m^6}$$<br>`+
-                     `$$L_b=${disp(lb)}\,\mathrm{m},\ E=${disp(e)}\,\mathrm{GPa},\ G=${disp(g)}\,\mathrm{GPa}$$<br>`+
-                     `$$C_1=${disp(c1)},\ C_2=${disp(c2)},\ C_3=${disp(c3)},\ k_w=${disp(kw)}$$<br>`+
-                     `$$M_{cr}=C_1 \frac{\pi^2 E I_z}{L_b^2} \sqrt{\frac{I_w}{I_z}+\frac{L_b^2 G I_t}{\pi^2 E I_z}}=${disp(mcr)}\\,\mathrm{kN\\,m},\ \chi_{LT}=${disp(chi)}$$`;
+        div.innerHTML=String.raw`$$M_{Rd}=\frac{W f_y}{\gamma_{M0}}=${disp(mRd)}\,\mathrm{kN\,m}$$<br>`+
+                     String.raw`$$M_{Rd,LBA}=\chi_{LT} \frac{W f_y}{\gamma_{M0}}=${disp(mRdLBA)}\,\mathrm{kN\,m}$$<br>`+
+                     String.raw`$$V_{Rd}=\frac{A_v f_y}{\sqrt{3}\,\gamma_{M0}}=${disp(vRd)}\,\mathrm{kN}$$<br>`+
+                     String.raw`$$I_z=${disp(iz)}\,\mathrm{m^4},\ I_t=${disp(it)}\,\mathrm{m^4},\ I_w=${disp(iw)}\,\mathrm{m^6}$$<br>`+
+                     String.raw`$$L_b=${disp(lb)}\,\mathrm{m},\ E=${disp(e)}\,\mathrm{GPa},\ G=${disp(g)}\,\mathrm{GPa}$$<br>`+
+                     String.raw`$$C_1=${disp(c1)},\ C_2=${disp(c2)},\ C_3=${disp(c3)},\ k_w=${disp(kw)}$$<br>`+
+                     String.raw`$$M_{cr}=C_1 \frac{\pi^2 E I_z}{L_b^2} \sqrt{\frac{I_w}{I_z}+\frac{L_b^2 G I_t}{\pi^2 E I_z}}=${disp(mcr)}\,\mathrm{kN\,m},\ \chi_{LT}=${disp(chi)}$$`;
     }
     if(window.MathJax) MathJax.typesetPromise([div]);
 }


### PR DESCRIPTION
## Summary
- use `String.raw` when writing LaTeX strings

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685db01ec5d88320b48a8ac4af203736