### PR TITLE
Fix hang when selecting timber material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1092,7 +1092,6 @@ function restrictTimberGrade(series){
     const g=timberGrades[sel.value];
     if(g){ state.E=g.E; state.fm_k=g.fm_k; state.fv_k=g.fv_k; }
     populateSectionSelect();
-    populateDesignSelect();
 }
 
 function computeSectionOutline(cs){


### PR DESCRIPTION
## Summary
- prevent infinite recursion in `restrictTimberGrade`
- add `.gitignore` for development artifacts

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: could not launch browser)*

------
https://chatgpt.com/codex/tasks/task_e_685e58ff6a84832084812d946f8d03a3