### PR TITLE
Fix infinite loop when selecting timber

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,7 +1096,8 @@ function restrictTimberGrade(series){
     }
     const g=timberGrades[sel.value];
     if(g){ state.E=g.E; state.fm_k=g.fm_k; state.fv_k=g.fv_k; }
-    populateSectionSelect();
+    // Avoid infinite recursion by not repopulating the section list here.
+    // The caller should refresh the options when necessary.
 }
 
 function computeSectionOutline(cs){


### PR DESCRIPTION
## Summary
- prevent `restrictTimberGrade` from repopulating the section list, which caused an infinite loop

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685e6a5ba36c8320bcf3da5018c895fb