### PR TITLE
Fix disabled glulam grade option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1086,13 +1086,10 @@ function populateTimberSelect(){
 function restrictTimberGrade(series){
     const sel=document.getElementById('timberSelect');
     if(!sel) return;
-    Array.from(sel.options).forEach(opt=>{ opt.disabled=false; });
     if(series==='sawn'){
         sel.value='C24';
-        Array.from(sel.options).forEach(opt=>{ opt.disabled=opt.value!=='C24'; });
     } else if(series==='glulam'){
         sel.value='GL30c';
-        Array.from(sel.options).forEach(opt=>{ opt.disabled=opt.value!=='GL30c'; });
     }
     const g=timberGrades[sel.value];
     if(g){ state.E=g.E; state.fm_k=g.fm_k; state.fv_k=g.fv_k; }


### PR DESCRIPTION
## Summary
- keep both timber grades selectable when cross section changes

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685e7aa44460832091f461a3f712ec6d