### PR TITLE
Fix timber grade filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@ const timberGrades = {
 function getFilteredSectionNames(){
     if(state.material==='timber'){
         const grade=document.getElementById('timberSelect')?.value;
-        const series=grade==='GL30c'?'glulam':'sawn';
+        const series=/^GL/i.test(grade)?'glulam':'sawn';
         return Object.keys(timberSections).filter(n=>timberSections[n].series===series);
     }
     return Object.keys(crossSections);


### PR DESCRIPTION
## Summary
- broaden detection of glulam grades when filtering timber sections

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685e7f608efc8320aed7d585e4860b60