### PR TITLE
Fix timber grade dropdown behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -1086,10 +1086,14 @@ function populateTimberSelect(){
 function restrictTimberGrade(series){
     const sel=document.getElementById('timberSelect');
     if(!sel) return;
+    const prev=sel.value;
     if(series==='sawn'){
         sel.value='C24';
     } else if(series==='glulam'){
         sel.value='GL30c';
+    }
+    if(sel.value!==prev){
+        sel.dispatchEvent(new Event('change'));
     }
     const g=timberGrades[sel.value];
     if(g){ state.E=g.E; state.fm_k=g.fm_k; state.fv_k=g.fv_k; }


### PR DESCRIPTION
## Summary
- trigger change event when restrictTimberGrade alters the selected grade

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685e866112c883208f293fa78f3c6da2