### PR TITLE
Fix glulam selection update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,8 +1075,8 @@ function populateTimberSelect(){
         state.E=g.E;
         state.fm_k=g.fm_k;
         state.fv_k=g.fv_k;
-        populateSectionSelect();
         populateDesignSelect();
+        populateSectionSelect();
         updateDesignProps(document.getElementById('designSectionSelect').value);
     };
     sel.onchange=apply;


### PR DESCRIPTION
## Summary
- fix timber grade change handler order to populate Design dropdown before Analysis

## Testing
- `npm ci` *(fails: no package-lock)*
- `npm install` *(fails: puppeteer download blocked)*
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685e9462bfd0832093b683abf491a3b9