### PR TITLE
Fix cross-section viewBox scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,18 +1159,14 @@ function drawSectionGraphic(cs){
     svg.innerHTML = '';
     if (!cs) { return; }
 
-    const width = svg.clientWidth;
-    const height = svg.clientHeight;
-    const margin = Math.max(cs.h_mm, cs.b_mm) * 0.1;
+    const maxDim = Math.max(cs.b_mm, cs.h_mm);
+    const pad = Math.max(maxDim * 0.1, 20);
+    const viewW = cs.b_mm + 2 * pad;
+    const viewH = cs.h_mm + 2 * pad;
+    svg.setAttribute('viewBox', `0 0 ${viewW} ${viewH}`);
 
-    const scale = Math.min(
-        (width - 2 * margin) / cs.b_mm,
-        (height - 2 * margin) / cs.h_mm
-    );
-    const x0 = (width - cs.b_mm * scale) / 2;
-    const y0 = (height - cs.h_mm * scale) / 2;
-    const mapX = x => x0 + x * scale;
-    const mapY = y => height - (y0 + y * scale);
+    const mapX = x => pad + x;
+    const mapY = y => viewH - pad - y;
 
     const points = computeSectionOutline(cs).map(p => [mapX(p.x), mapY(p.y)]);
     const svgSel = d3.select(svg);


### PR DESCRIPTION
## Summary
- auto-size section graphic by computing viewBox from the selected profile
- keep measurements visible with minimum padding

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: no package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ec7440b088320bec0a1259288d41a