### PR TITLE
Update frame tab UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,36 +268,28 @@
 
     <div id="frameTab" class="tabcontent">
         <div class="section">
+            <h2>Beams</h2>
+            <div id="frameBeams"></div>
+            <button onclick="addFrameBeam()">Add Beam</button>
+        </div>
+        <div class="section">
+            <h2>Supports</h2>
+            <div id="frameSupports"></div>
+            <button onclick="addFrameSupport()">Add Support</button>
+        </div>
+        <div class="section">
+            <h2>Point Loads</h2>
+            <div id="frameLoads"></div>
+            <button onclick="addFrameLoad()">Add Load</button>
+        </div>
+        <div class="section">
+            <button onclick="solveFrame()">Solve</button>
             <canvas id="frameCanvas" width="600" height="400" style="border:1px solid #ccc;"></canvas>
-            <div style="margin-top:10px;">
-                <button onclick="setFrameTool('beam')">Beam</button>
-                <button onclick="setFrameTool('support')">Support</button>
-                <button onclick="setFrameTool('load')">Load</button>
-                <button onclick="deleteFrameSelected()">Delete</button>
-                <button onclick="solveFrame()">Solve</button>
-            </div>
-        </div>
-        <div class="section full-width">
-            <h2>Deflection</h2>
-            <canvas id="frameDeflectionChart"></canvas>
-        </div>
-        <div class="section full-width">
-            <h2>Bending Moment</h2>
-            <canvas id="frameMomentChart"></canvas>
-        </div>
-        <div class="section full-width">
-            <h2>Shear Force</h2>
-            <canvas id="frameShearChart"></canvas>
-        </div>
-        <div class="section full-width">
-            <h2>Normal Force</h2>
-            <canvas id="frameNormalChart"></canvas>
         </div>
     </div> <!-- end frameTab -->
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
-    <script src="https://cdn.jsdelivr.net/npm/paper@0.12.15/dist/paper-full.min.js"></script>
     <script src="./steel_cross_sections_data.js"></script>
     <script src="./timber_cross_sections_data.js"></script>
     <script src="./solver.js"></script>
@@ -1429,103 +1421,192 @@ addCombination('Comb1','SW:1.35,LC1:1.50');
 addCombination('Comb2','SW:0.90,LC1:1.50');
 solveSelected();
 
-// Frame tab logic
-const frameState={nodes:[],beams:[],loads:[],supports:[]};
-let frameTool='beam';
-let frameTemp=null,frameTempNode=null,frameSelected=null;
+// Frame tab logic (list based)
+const frameState={beams:[],supports:[],loads:[],nodes:[]};
 
-function initFrame(){
-    if(!window.paper) return;
-    paper.setup('frameCanvas');
-    const tool=new paper.Tool();
-    tool.onMouseDown=e=>{
-        const hit=paper.project.hitTest(e.point,{segments:true,stroke:true,fill:true});
-        if(hit && hit.item){
-            if(frameSelected) frameSelected.selected=false;
-            frameSelected=hit.item;
-            frameSelected.selected=true;
-            return;
-        }
-        if(frameTool==='beam'){
-            if(!frameTemp){
-                frameTempNode=addFrameNode(e.point);
-                frameTemp=e.point;
-                new paper.Path.Circle(e.point,3).fillColor='blue';
-            } else {
-                const n1=frameTempNode;
-                const n2=addFrameNode(e.point);
-                const path=new paper.Path.Line(frameTemp,e.point);
-                path.strokeColor='black';
-                path.data={type:'beam',n1,n2};
-                frameState.beams.push({n1,n2,path});
-                frameTemp=null; frameTempNode=null;
-            }
-        } else if(frameTool==='support'){
-            const n=addFrameNode(e.point);
-            const c=new paper.Path.Circle(e.point,5);
-            c.fillColor='green';
-            c.data={type:'support',node:n,fixX:true,fixY:true,fixRot:true};
-            frameState.supports.push({node:n,fixX:true,fixY:true,fixRot:true,path:c});
-        } else if(frameTool==='load'){
-            const n=addFrameNode(e.point);
-            const arr=new paper.Path.Line(e.point,e.point.add([0,-20]));
-            arr.strokeColor='red';
-            arr.data={type:'load',node:n,Py:-1000};
-            frameState.loads.push({node:n,Py:-1000,path:arr});
-        }
-    };
+function addFrameBeam(){
+    const first=Object.keys(crossSections)[0]||'';
+    frameState.beams.push({x1:0,y1:0,x2:1,y2:0,section:first});
+    rebuildFrameBeams();
+    rebuildNodes();
+    rebuildNodeOptions();
 }
 
-function addFrameNode(p){
-    const idx=frameState.nodes.findIndex(n=>n.x===p.x&&n.y===p.y);
-    if(idx>-1) return idx;
-    frameState.nodes.push({x:p.x,y:p.y});
-    return frameState.nodes.length-1;
+function removeFrameBeam(i){
+    frameState.beams.splice(i,1);
+    rebuildFrameBeams();
+    rebuildNodes();
+    rebuildNodeOptions();
 }
 
-function setFrameTool(t){frameTool=t;}
+function rebuildFrameBeams(){
+    const c=document.getElementById('frameBeams');
+    c.innerHTML='';
+    frameState.beams.forEach((b,i)=>{
+        const row=document.createElement('div');
+        row.className='input-row';
+        const opts=Object.keys(crossSections).sort().map(n=>`<option value="${n}"${n===b.section?' selected':''}>${n}</option>`).join('');
+        row.innerHTML=`<label>Beam ${i+1}:</label>`+
+            `x1:<input type='number' value='${b.x1}' step='0.1' onchange='frameState.beams[${i}].x1=parseFloat(this.value); rebuildNodes(); rebuildNodeOptions();'/>`+
+            `y1:<input type='number' value='${b.y1}' step='0.1' onchange='frameState.beams[${i}].y1=parseFloat(this.value); rebuildNodes(); rebuildNodeOptions();'/>`+
+            `x2:<input type='number' value='${b.x2}' step='0.1' onchange='frameState.beams[${i}].x2=parseFloat(this.value); rebuildNodes(); rebuildNodeOptions();'/>`+
+            `y2:<input type='number' value='${b.y2}' step='0.1' onchange='frameState.beams[${i}].y2=parseFloat(this.value); rebuildNodes(); rebuildNodeOptions();'/>`+
+            `<select onchange='frameState.beams[${i}].section=this.value'>${opts}</select>`+
+            `<button class='remove-btn' onclick='removeFrameBeam(${i})'>Remove</button>`;
+        c.appendChild(row);
+    });
+}
 
-function deleteFrameSelected(){
-    if(!frameSelected) return;
-    const d=frameSelected.data;
-    if(d.type==='beam'){frameState.beams=frameState.beams.filter(b=>b.path!==frameSelected);} 
-    else if(d.type==='support'){frameState.supports=frameState.supports.filter(s=>s.path!==frameSelected);} 
-    else if(d.type==='load'){frameState.loads=frameState.loads.filter(l=>l.path!==frameSelected);} 
-    frameSelected.remove(); frameSelected=null;
+function addFrameSupport(){
+    frameState.supports.push({node:0,fixX:true,fixY:true,fixRot:true});
+    rebuildFrameSupports();
+}
+
+function removeFrameSupport(i){
+    frameState.supports.splice(i,1);
+    rebuildFrameSupports();
+}
+
+function rebuildFrameSupports(){
+    const c=document.getElementById('frameSupports');
+    c.innerHTML='';
+    frameState.supports.forEach((s,i)=>{
+        const opts=frameState.nodes.map((n,j)=>`<option value="${j}"${j===s.node?' selected':''}>${j}</option>`).join('');
+        const row=document.createElement('div');
+        row.className='input-row';
+        row.innerHTML=`<label>Support ${i+1}:</label>`+
+            `<select class='node-select' onchange='frameState.supports[${i}].node=parseInt(this.value)'>${opts}</select>`+
+            ` Fx<input type='checkbox' ${s.fixX?'checked':''} onchange='frameState.supports[${i}].fixX=this.checked'/>`+
+            ` Fy<input type='checkbox' ${s.fixY?'checked':''} onchange='frameState.supports[${i}].fixY=this.checked'/>`+
+            ` Mz<input type='checkbox' ${s.fixRot?'checked':''} onchange='frameState.supports[${i}].fixRot=this.checked'/>`+
+            `<button class='remove-btn' onclick='removeFrameSupport(${i})'>Remove</button>`;
+        c.appendChild(row);
+    });
+}
+
+function addFrameLoad(){
+    frameState.loads.push({node:0,Fx:0,Fz:-1000,My:0});
+    rebuildFrameLoads();
+}
+
+function removeFrameLoad(i){
+    frameState.loads.splice(i,1);
+    rebuildFrameLoads();
+}
+
+function rebuildFrameLoads(){
+    const c=document.getElementById('frameLoads');
+    c.innerHTML='';
+    frameState.loads.forEach((l,i)=>{
+        const opts=frameState.nodes.map((n,j)=>`<option value="${j}"${j===l.node?' selected':''}>${j}</option>`).join('');
+        const row=document.createElement('div');
+        row.className='input-row';
+        row.innerHTML=`<label>Load ${i+1}:</label>`+
+            `<select class='node-select' onchange='frameState.loads[${i}].node=parseInt(this.value)'>${opts}</select>`+
+            ` Fx:<input type='number' value='${l.Fx}' step='1' onchange='frameState.loads[${i}].Fx=parseFloat(this.value)'/>`+
+            ` Fz:<input type='number' value='${l.Fz}' step='1' onchange='frameState.loads[${i}].Fz=parseFloat(this.value)'/>`+
+            ` My:<input type='number' value='${l.My}' step='1' onchange='frameState.loads[${i}].My=parseFloat(this.value)'/>`+
+            `<button class='remove-btn' onclick='removeFrameLoad(${i})'>Remove</button>`;
+        c.appendChild(row);
+    });
+}
+
+function rebuildNodes(){
+    const nodes=[]; const map={};
+    frameState.beams.forEach(b=>{
+        const k1=b.x1+','+b.y1;
+        if(map[k1]===undefined){map[k1]=nodes.length; nodes.push({x:parseFloat(b.x1),y:parseFloat(b.y1)});}
+        const k2=b.x2+','+b.y2;
+        if(map[k2]===undefined){map[k2]=nodes.length; nodes.push({x:parseFloat(b.x2),y:parseFloat(b.y2)});}
+        b.n1=map[k1]; b.n2=map[k2];
+    });
+    frameState.nodes=nodes;
+}
+
+function rebuildNodeOptions(){
+    document.querySelectorAll('.node-select').forEach(sel=>{
+        const cur=sel.value;
+        sel.innerHTML=frameState.nodes.map((n,i)=>`<option value="${i}">${i}</option>`).join('');
+        if(Array.from(sel.options).some(o=>o.value===cur)) sel.value=cur;
+    });
 }
 
 function solveFrame(){
-    const res=computeFrameResults(frameState);
+    rebuildNodes();
+    const beams=frameState.beams.map(b=>{
+        const cs=crossSections[b.section]||{};
+        const I=cs.I_y||cs.Iy_m4||cs.I_z||cs.Iz_m4||1e-6;
+        const A=cs.A_m2||0.001;
+        return {n1:b.n1,n2:b.n2,E:state.E,I,A};
+    });
+    const supports=frameState.supports.map(s=>({node:s.node,fixX:s.fixX,fixY:s.fixY,fixRot:s.fixRot}));
+    const loads=frameState.loads.map(l=>({node:l.node,Px:l.Fx||0,Py:l.Fz||0,Mz:l.My||0}));
+    const frame={nodes:frameState.nodes,beams,supports,loads,E:state.E};
+    const res=computeFrameResults(frame);
     if(!res) return;
-    const diags=computeFrameDiagrams(frameState,res);
-    updateFrameCharts(res,diags);
+    const diags=computeFrameDiagrams(frame,res);
+    drawFrame(res,diags);
 }
 
-function updateFrameCharts(res,diags){
-    const xs=frameState.nodes.map((n,i)=>i);
-    const def=frameState.nodes.map((_,i)=>-res.displacements[3*i+1]*1000);
-    createFrameChart('frameDeflectionChart',xs,def,'Deflection','blue');
+function drawFrame(res,diags){
+    const canvas=document.getElementById('frameCanvas');
+    const ctx=canvas.getContext('2d');
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    if(frameState.nodes.length===0) return;
+    const xs=frameState.nodes.map(n=>n.x);
+    const ys=frameState.nodes.map(n=>n.y);
+    const minX=Math.min(...xs), maxX=Math.max(...xs);
+    const minY=Math.min(...ys), maxY=Math.max(...ys);
+    const pad=40;
+    const sx=(canvas.width-2*pad)/(maxX-minX||1);
+    const sy=(canvas.height-2*pad)/(maxY-minY||1);
+    const mx=x=>pad+(x-minX)*sx;
+    const my=y=>canvas.height-(pad+(y-minY)*sy);
 
-    const makeDatasets=(arr,scale)=>arr.map((seg,i)=>({label:'B'+i,data:seg.map(p=>({x:p.x,y:p.y/scale})),fill:false,showLine:true,borderColor:'blue'}));
-    const shearDS=makeDatasets(diags.map(d=>d.shear),1000);
-    const momentDS=makeDatasets(diags.map(d=>d.moment),1000);
-    const normalDS=makeDatasets(diags.map(d=>d.normal),1000);
-    createFrameChart('frameShearChart',null,null,'Shear',null,shearDS);
-    createFrameChart('frameMomentChart',null,null,'Moment',null,momentDS);
-    createFrameChart('frameNormalChart',null,null,'Normal',null,normalDS);
-}
+    ctx.strokeStyle='gray';
+    frameState.beams.forEach(b=>{
+        const n1=frameState.nodes[b.n1];
+        const n2=frameState.nodes[b.n2];
+        ctx.beginPath();
+        ctx.moveTo(mx(n1.x),my(n1.y));
+        ctx.lineTo(mx(n2.x),my(n2.y));
+        ctx.stroke();
+    });
 
-function createFrameChart(id,x,y,label,color,datasets){
-    const ctx=document.getElementById(id).getContext('2d');
-    if(window[id+'Obj']){window[id+'Obj'].destroy();}
-    if(!datasets){
-        const data=x.map((v,i)=>({x:v,y:y[i]}));
-        datasets=[{label:label,data,borderColor:color,fill:false,showLine:true}];
+    ctx.fillStyle='black';
+    ctx.font='12px sans-serif';
+    frameState.nodes.forEach((n,i)=>{
+        const x=mx(n.x), y=my(n.y);
+        ctx.beginPath();
+        ctx.arc(x,y,3,0,2*Math.PI);
+        ctx.fill();
+        ctx.fillText(i,x+4,y-4);
+    });
+
+    if(res){
+        const scale=40;
+        ctx.strokeStyle='blue';
+        frameState.beams.forEach((b,i)=>{
+            const n1=frameState.nodes[b.n1];
+            const n2=frameState.nodes[b.n2];
+            const d1={x:res.displacements[3*b.n1],y:res.displacements[3*b.n1+1]};
+            const d2={x:res.displacements[3*b.n2],y:res.displacements[3*b.n2+1]};
+            ctx.beginPath();
+            ctx.moveTo(mx(n1.x+d1.x*scale),my(n1.y+d1.y*scale));
+            ctx.lineTo(mx(n2.x+d2.x*scale),my(n2.y+d2.y*scale));
+            ctx.stroke();
+            const midX=(n1.x+n2.x)/2; const midY=(n1.y+n2.y)/2;
+            const M=diags[i].moment[0].y.toFixed(1);
+            ctx.fillText(M,mx(midX),my(midY)-10);
+        });
     }
-    window[id+'Obj']=new Chart(ctx,{type:'line',data:{datasets},options:{scales:{x:{type:'linear'},y:{title:{display:true,text:label}}}}});
 }
 
-window.addEventListener('load',initFrame);
+window.addEventListener('load',()=>{
+    rebuildFrameBeams();
+    rebuildFrameSupports();
+    rebuildFrameLoads();
+});
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor frame tab from drawing UI to input lists
- remove Paper.js and add functions to build FEM from beam, support and load lists
- show deformed frame with moments directly on canvas

## Testing
- `npm ci` *(fails: no package-lock)*
- `npm install --ignore-scripts`
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: missing Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6862abf313608320be74c0e2597d6ff3