### PR TITLE
Fix dimension padding on cross‑section SVG

### DIFF
--- a/index.html
+++ b/index.html
@@ -1228,7 +1228,8 @@ function drawSectionGraphic(cs){
     if (!cs) { return; }
 
     const maxDim = Math.max(cs.b_mm, cs.h_mm);
-    const pad = Math.max(maxDim * 0.1, 20);
+    const basePad = Math.max(maxDim * 0.1, 20);
+    const pad = basePad + 20; // extra room for dimension arrows
     const viewW = cs.b_mm + 2 * pad;
     const viewH = cs.h_mm + 2 * pad;
     svg.setAttribute('viewBox', `0 0 ${viewW} ${viewH}`);


### PR DESCRIPTION
## Summary
- keep extra margin around cross-section diagrams so that dimension arrows never clip

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: missing package-lock.json)*
- `npm install` *(fails: blocked download for puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68638ddc0ae48320b9e24a7f72034147