### PR TITLE
Improve frame analysis and visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,8 @@
                 <div id="frameToolbar">
                     <label>Deflection scale</label>
                     <input type="range" id="frameDefScale" min="0" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
+                    <label style="margin-left:10px;">Member division</label>
+                    <input type="number" id="frameDiv" value="5" min="1" step="1" onchange="solveFrame()" style="width:60px;">
                     <select id="frameDiagSelect" onchange="drawFrame(frameRes,frameDiags)">
                         <option value="moment">Bending moment</option>
                         <option value="shear">Shear force</option>
@@ -1451,6 +1453,10 @@ let frameRes=null;
 let frameDiags=null;
 let framePaper=null;
 
+function mulMV(A,x){
+    return A.map(r=>r.reduce((s,v,i)=>s+v*x[i],0));
+}
+
 function addFrameBeam(){
     const first=Object.keys(crossSections)[0]||'';
     frameState.beams.push({x1:0,y1:0,x2:1,y2:0,section:first});
@@ -1580,7 +1586,8 @@ function solveFrame(){
     const frame={nodes:frameState.nodes,beams,supports,loads,E:state.E};
     const res=computeFrameResults(frame);
     if(!res) return;
-    const diags=computeFrameDiagrams(frame,res);
+    const div=parseInt(document.getElementById('frameDiv')?.value||'1');
+    const diags=computeFrameDiagrams(frame,res,div);
     frameRes=res;
     frameDiags=diags;
     drawFrame(res,diags);
@@ -1672,17 +1679,32 @@ function drawFrame(res,diags){
     if(res){
         const scaleInput=document.getElementById('frameDefScale');
         const dispScale=40*(scaleInput?parseFloat(scaleInput.value||'1'):1);
+        const div=parseInt(document.getElementById('frameDiv')?.value||'1');
         frameState.beams.forEach((b,i)=>{
             const n1=frameState.nodes[b.n1];
             const n2=frameState.nodes[b.n2];
-            const d1={x:res.displacements[3*b.n1],y:res.displacements[3*b.n1+1]};
-            const d2={x:res.displacements[3*b.n2],y:res.displacements[3*b.n2+1]};
-            new framePaper.Path.Line({from:toPoint(n1.x+d1.x*dispScale,n1.y+d1.y*dispScale), to:toPoint(n2.x+d2.x*dispScale,n2.y+d2.y*dispScale), strokeColor:'blue'});
+            const dx=n2.x-n1.x, dy=n2.y-n1.y;
+            const L=Math.hypot(dx,dy);
+            const c=dx/L, s=dy/L;
+            const dofs=[3*b.n1,3*b.n1+1,3*b.n1+2,3*b.n2,3*b.n2+1,3*b.n2+2];
+            const dGlobal=dofs.map(idx=>res.displacements[idx]);
+            const T=[[ c, s,0,0,0,0],[-s, c,0,0,0,0],[0,0,1,0,0,0],[0,0,0, c,s,0],[0,0,0,-s,c,0],[0,0,0,0,0,1]];
+            const dLocal=mulMV(T,dGlobal);
+            const path=new framePaper.Path({strokeColor:'blue'});
+            for(let j=0;j<=div;j++){
+                const t=j/div;
+                const x=t*L;
+                const u=dLocal[0]*(1-t)+dLocal[3]*t;
+                const w=dLocal[1]*(1-3*t*t+2*t*t*t)+dLocal[2]*(x-2*x*x/L+x*x*x/(L*L))+dLocal[4]*(3*t*t-2*t*t*t)+dLocal[5]*(-x*x/L+x*x*x/(L*L));
+                const gx=n1.x+dx*t + (c*u - s*w)*dispScale;
+                const gy=n1.y+dy*t + (s*u + c*w)*dispScale;
+                path.add(toPoint(gx,gy));
+            }
         });
 
         const type=document.getElementById('frameDiagSelect').value;
         let maxVal=0;
-        diags.forEach(d=>{maxVal=Math.max(maxVal,Math.abs(d[type][0].y),Math.abs(d[type][1].y));});
+        diags.forEach(d=>{d[type].forEach(pt=>{maxVal=Math.max(maxVal,Math.abs(pt.y));});});
         const diagScale=30/(maxVal||1);
         frameState.beams.forEach((b,i)=>{
             const n1=frameState.nodes[b.n1];
@@ -1691,28 +1713,42 @@ function drawFrame(res,diags){
             const p2=toPoint(n2.x,n2.y);
             const dir=p2.subtract(p1).normalize();
             const perp=dir.rotate(90);
-            const v1=diags[i][type][0].y;
-            const v2=diags[i][type][1].y;
+            const vals=diags[i][type];
             const path=new framePaper.Path({strokeColor:'red', fillColor:'rgba(255,0,0,0.3)'});
             path.add(p1);
-            if(type==='normal'){
-                path.add(p1.add(dir.multiply(v1*diagScale)));
-                path.add(p2.add(dir.multiply(v2*diagScale)));
-            }else{
-                path.add(p1.add(perp.multiply(v1*diagScale)));
-                path.add(p2.add(perp.multiply(v2*diagScale)));
-            }
+            vals.forEach((pt,j)=>{
+                const t=j/(vals.length-1);
+                const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
+                path.add(base.add(perp.multiply(pt.y*diagScale)));
+            });
             path.add(p2);
             path.closed=true;
-            const labelDir=type==='normal'?perp:perp;
-            const mid=p1.add(p2).divide(2).add(labelDir.multiply(((v1+v2)/2)*diagScale+10));
-            new framePaper.PointText({point:mid, content:((v1+v2)/2).toFixed(1), fontSize:10});
+            vals.forEach((pt,j)=>{
+                const t=j/(vals.length-1);
+                const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
+                const labelPos=base.add(perp.multiply(pt.y*diagScale+10));
+                new framePaper.PointText({point:labelPos, content:pt.y.toFixed(1), fontSize:10});
+            });
         });
     }
     framePaper.view.update();
 }
 
 window.addEventListener('load',()=>{
+    frameState.beams=[
+        {x1:0,y1:0,x2:0,y2:5,section:'HEA200'},
+        {x1:6,y1:0,x2:6,y2:5,section:'HEA200'},
+        {x1:0,y1:5,x2:6,y2:5,section:'HEA200'}
+    ];
+    rebuildNodes();
+    frameState.supports=[
+        {node:0,fixX:true,fixY:true,fixRot:true},
+        {node:2,fixX:true,fixY:true,fixRot:true}
+    ];
+    frameState.loads=[
+        {node:1,Fx:25000,Fz:-200000,My:0},
+        {node:3,Fx:25000,Fz:-200000,My:0}
+    ];
     rebuildFrameBeams();
     rebuildFrameSupports();
     rebuildFrameLoads();

--- a/solver.js
+++ b/solver.js
@@ -431,7 +431,7 @@ function computeFrameResults(frame){
     return {displacements:full};
 }
 
-function computeFrameDiagrams(frame,res){
+function computeFrameDiagrams(frame,res,divisions=1){
     const diags=[];
     frame.beams.forEach(el=>{
         const n1=el.n1,n2=el.n2;
@@ -456,11 +456,14 @@ function computeFrameDiagrams(frame,res){
         const N1=-fLocal[0], N2=-fLocal[3];
         const V1=fLocal[1], V2=-fLocal[4];
         const M1=fLocal[2], M2=-fLocal[5];
-        diags.push({
-            shear:[{x:0,y:V1},{x:L,y:V2}],
-            moment:[{x:0,y:M1},{x:L,y:M2}],
-            normal:[{x:0,y:N1},{x:L,y:N2}]
-        });
+        const shear=[], moment=[], normal=[];
+        for(let j=0;j<=divisions;j++){
+            const t=j/divisions;
+            shear.push({x:t*L,y:V1+(V2-V1)*t});
+            moment.push({x:t*L,y:M1+(M2-M1)*t});
+            normal.push({x:t*L,y:N1+(N2-N1)*t});
+        }
+        diags.push({shear,moment,normal});
     });
     return diags;
 }


### PR DESCRIPTION
## Summary
- allow setting member division in the frame view
- show internal force values at each FE node
- draw normal force diagrams correctly
- show curved deflection shapes
- provide default 6x5 m HEA200 frame
- subdivide internal forces in solver

## Testing
- `npm test`
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6863a69050348320bf12bc178d6182f1