### PR TITLE
Fix frame tab rendering issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1439,6 +1439,10 @@ function showTab(name){
         const sel=document.getElementById('designSectionSelect');
         if(sel) updateDesignProps(sel.value);
     }
+    if(name==='frame'){
+        // redraw frame diagram after tab becomes visible
+        drawFrame(frameRes, frameDiags);
+    }
 }
 
 addSpan(10);


### PR DESCRIPTION
## Summary
- make Frame tab redraw the diagram when shown

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: no `package-lock.json` present)*

------
https://chatgpt.com/codex/tasks/task_e_6863aa8ccb1c83208c06c5202b98477b