### PR TITLE
Fix frame diagram rendering size

### DIFF
--- a/index.html
+++ b/index.html
@@ -1604,8 +1604,11 @@ function drawFrame(res,diags){
     if(!framePaper){
         framePaper=new paper.PaperScope();
         framePaper.setup(canvas);
+        framePaper.view.viewSize = new framePaper.Size(canvas.width, canvas.height);
     }else{
         framePaper.project.clear();
+        // ensure the paper view matches the resized canvas
+        framePaper.view.viewSize = new framePaper.Size(canvas.width, canvas.height);
     }
     if(frameState.nodes.length===0){ framePaper.view.update(); return; }
 


### PR DESCRIPTION
## Summary
- ensure Paper.js canvas view updates when the frame diagram is redrawn

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: requires package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863acfac9088320b85481b9716f42fa