### PR TITLE
Fix frame tab canvas resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1441,7 +1441,7 @@ function showTab(name){
     }
     if(name==='frame'){
         // redraw frame diagram after tab becomes visible
-        drawFrame(frameRes, frameDiags);
+        requestAnimationFrame(()=>drawFrame(frameRes, frameDiags));
     }
 }
 
@@ -1594,13 +1594,19 @@ function solveFrame(){
     const diags=computeFrameDiagrams(frame,res,div);
     frameRes=res;
     frameDiags=diags;
-    drawFrame(res,diags);
+    if(document.getElementById('frameTab').style.display!=='none'){
+        drawFrame(res,diags);
+    }
 }
 
 function drawFrame(res,diags){
     const canvas=document.getElementById('frameCanvas');
-    canvas.width = canvas.clientWidth;
-    canvas.height = canvas.clientHeight;
+    const cW = canvas.clientWidth;
+    const cH = canvas.clientHeight;
+    if(cW && cH){
+        canvas.width = cW;
+        canvas.height = cH;
+    }
     if(!framePaper){
         framePaper=new paper.PaperScope();
         framePaper.setup(canvas);


### PR DESCRIPTION
## Summary
- avoid resizing frame canvas when tab is hidden
- redraw frame canvas with `requestAnimationFrame`
- guard canvas buffer resizing when dimensions are zero

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6863b084fa08832081999ceea27bc7ec