### PR TITLE
Fix deflection slider scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
             <div id="frameDiagram" class="section">
                 <div id="frameToolbar">
                     <label>Deflection scale</label>
-                    <input type="range" id="frameDefScale" min="0" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
+                    <input type="range" id="frameDefScale" min="0.1" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
                     <label style="margin-left:10px;">Member division</label>
                     <input type="number" id="frameDiv" value="5" min="1" step="1" onchange="solveFrame()" style="width:60px;">
                     <select id="frameDiagSelect" onchange="drawFrame(frameRes,frameDiags)">
@@ -1616,6 +1616,10 @@ function drawFrame(res,diags){
         // ensure the paper view matches the resized canvas
         framePaper.view.viewSize = new framePaper.Size(canvas.width, canvas.height);
     }
+    // reset any transforms applied to the view
+    if(framePaper.view && framePaper.view.matrix && framePaper.view.matrix.reset){
+        framePaper.view.matrix.reset();
+    }
     if(frameState.nodes.length===0){ framePaper.view.update(); return; }
 
     const xs=frameState.nodes.map(n=>n.x);
@@ -1691,7 +1695,9 @@ function drawFrame(res,diags){
 
     if(res){
         const scaleInput=document.getElementById('frameDefScale');
-        const dispScale=40*(scaleInput?parseFloat(scaleInput.value||'1'):1);
+        const userVal=scaleInput?parseFloat(scaleInput.value||'1'):1;
+        const defScale=Math.max(userVal,0.1);
+        const dispScale=40*defScale;
         const div=parseInt(document.getElementById('frameDiv')?.value||'1');
         frameState.beams.forEach((b,i)=>{
             const n1=frameState.nodes[b.n1];


### PR DESCRIPTION
## Summary
- clamp the deflection slider so it can't be zero
- reset the Paper.js view matrix on each frame draw
- avoid zero scale by applying a minimum in JS

## Testing
- `npm ci` *(fails: no package-lock)*
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6863b707af648320ad8a85f7a565a185