### PR TITLE
Fix frame load defaults and axial force sign

### DIFF
--- a/index.html
+++ b/index.html
@@ -1528,7 +1528,8 @@ function rebuildFrameSupports(){
 }
 
 function addFrameLoad(){
-    frameState.loads.push({node:0,Fx:0,Fz:-1000,My:0});
+    // Default point load magnitude scaled down to avoid blowing up diagrams
+    frameState.loads.push({node:0,Fx:0,Fz:-1,My:0});
     rebuildFrameLoads();
     solveFrame();
 }
@@ -1715,8 +1716,10 @@ function drawFrame(res,diags){
                 const x=t*L;
                 const u=dLocal[0]*(1-t)+dLocal[3]*t;
                 const w=dLocal[1]*(1-3*t*t+2*t*t*t)+dLocal[2]*(x-2*x*x/L+x*x*x/(L*L))+dLocal[4]*(3*t*t-2*t*t*t)+dLocal[5]*(-x*x/L+x*x*x/(L*L));
-                const gx=n1.x+dx*t + (c*u - s*w)*dispScale;
-                const gy=n1.y+dy*t + (s*u + c*w)*dispScale;
+                // Do not scale axial displacements to avoid drifting when adjusting the
+                // deflection scale. Only the transverse component is magnified.
+                const gx=n1.x+dx*t - s*w*dispScale;
+                const gy=n1.y+dy*t + c*w*dispScale;
                 path.add(toPoint(gx,gy));
             }
         });
@@ -1764,9 +1767,10 @@ window.addEventListener('load',()=>{
         {node:0,fixX:true,fixY:true,fixRot:true},
         {node:2,fixX:true,fixY:true,fixRot:true}
     ];
+    // Initial example loads scaled down to sensible magnitudes
     frameState.loads=[
-        {node:1,Fx:25000,Fz:-200000,My:0},
-        {node:3,Fx:25000,Fz:-200000,My:0}
+        {node:1,Fx:25,Fz:-200,My:0},
+        {node:3,Fx:25,Fz:-200,My:0}
     ];
     rebuildFrameBeams();
     rebuildFrameSupports();

--- a/solver.js
+++ b/solver.js
@@ -453,7 +453,9 @@ function computeFrameDiagrams(frame,res,divisions=1){
         const dGlobal=dofs.map(i=>res.displacements[i]);
         const dLocal=multiplyMatrixVector(T,dGlobal);
         const fLocal=multiplyMatrixVector(kLocal,dLocal);
-        const N1=-fLocal[0], N2=-fLocal[3];
+        // Ensure axial forces have consistent sign at both ends.
+        // Compression is positive when fLocal[0] is negative.
+        const N1=-fLocal[0], N2=fLocal[3];
         const V1=fLocal[1], V2=-fLocal[4];
         const M1=fLocal[2], M2=-fLocal[5];
         const shear=[], moment=[], normal=[];


### PR DESCRIPTION
## Summary
- scale down default frame loads
- avoid scaling axial displacement when drawing deflection
- fix initial example loads
- normalize axial diagram sign for frames

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm install` *(fails: ERROR: Failed to set up chrome-headless-shell)*

------
https://chatgpt.com/codex/tasks/task_e_6863bb96f5e483208d69312386b19f74