### PR TITLE
Improve frame diagram behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@
                 <div id="frameToolbar">
                     <label>Deflection scale</label>
                     <input type="range" id="frameDefScale" min="0.1" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
+                    <div id="frameMaxDisp" style="font-size:12px;margin-top:4px;"></div>
                     <label style="margin-left:10px;">Member division</label>
                     <input type="number" id="frameDiv" value="5" min="1" step="1" onchange="solveFrame()" style="width:60px;">
                     <select id="frameDiagSelect" onchange="drawFrame(frameRes,frameDiags)">
@@ -1696,6 +1697,15 @@ function drawFrame(res,diags){
         const userVal=scaleInput?parseFloat(scaleInput.value||'1'):1;
         const defScale=Math.max(userVal,0.1);
         const dispScale=40*defScale;
+        const mags=frameState.nodes.map((_,i)=>{
+            const ux=res.displacements[3*i];
+            const uy=res.displacements[3*i+1];
+            return {i,val:Math.hypot(ux,uy)};
+        }).sort((a,b)=>b.val-a.val).slice(0,2);
+        const dispEl=document.getElementById('frameMaxDisp');
+        if(dispEl){
+            dispEl.textContent=mags.map(m=>`Node ${m.i}: ${(m.val*1000).toFixed(2)} mm`).join(', ');
+        }
         const div=parseInt(document.getElementById('frameDiv')?.value||'1');
         frameState.beams.forEach((b,i)=>{
             const n1=frameState.nodes[b.n1];
@@ -1715,7 +1725,7 @@ function drawFrame(res,diags){
                 const w=dLocal[1]*(1-3*t*t+2*t*t*t)+dLocal[2]*(x-2*x*x/L+x*x*x/(L*L))+dLocal[4]*(3*t*t-2*t*t*t)+dLocal[5]*(-x*x/L+x*x*x/(L*L));
                 // Use local coordinates to keep one end fixed while scaling only
                 // the transverse displacement component.
-                const xLocal=x+u; // axial displacement not scaled
+                const xLocal=x+u*dispScale; // magnified axial displacement
                 const yLocal=w*dispScale; // magnified transverse displacement
                 const gx=n1.x+c*xLocal - s*yLocal;
                 const gy=n1.y+s*xLocal + c*yLocal;
@@ -1737,17 +1747,18 @@ function drawFrame(res,diags){
             const vals=diags[i][type];
             const path=new framePaper.Path({strokeColor:'red', fillColor:'rgba(255,0,0,0.3)'});
             path.add(p1);
+            const sign=-1; // draw diagram on tension side
             vals.forEach((pt,j)=>{
                 const t=j/(vals.length-1);
                 const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
-                path.add(base.add(perp.multiply(pt.y*diagScale)));
+                path.add(base.add(perp.multiply(pt.y*diagScale*sign)));
             });
             path.add(p2);
             path.closed=true;
             vals.forEach((pt,j)=>{
                 const t=j/(vals.length-1);
                 const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
-                const labelPos=base.add(perp.multiply(pt.y*diagScale+10));
+                const labelPos=base.add(perp.multiply(pt.y*diagScale*sign+10));
                 new framePaper.PointText({point:labelPos, content:pt.y.toFixed(1), fontSize:10});
             });
         });


### PR DESCRIPTION
## Summary
- show node displacement magnitudes in the Frame tab
- magnify axial deformations when drawing deflected shape
- flip bending moment diagram to tension side

## Testing
- `npm ci` *(fails: lockfile missing)*
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6863e53ee9b08320b160e786637ce35f