### PR TITLE
Fix frame tab layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         .frame-row .cell input,
         .frame-row .cell select { width:70px; }
         #frameLayout { display:flex; flex-wrap:wrap; gap:20px; align-items:flex-start; }
-        #frameControls { flex:1 1 250px; max-width:350px; }
+        #frameControls { flex:1 1 100%; max-width:none; }
         #frameDiagram { flex:2 1 400px; min-height:520px; max-width:600px; }
         #frameDiagram canvas { width:100%; height:100%; max-width:600px; max-height:600px; }
         #frameToolbar { display:flex; gap:8px; margin-bottom:8px; align-items:center; }


### PR DESCRIPTION
## Summary
- expand Frame tab's input area width
- let frame diagram stack below input controls to avoid overlap

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6864354806c88320a21b36cc952f3f37