### PR TITLE
Fix release forces in frame diagrams

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -676,6 +676,12 @@ function computeFrameDiagrams(frame,res,divisions=1){
         });
 
         const fAdj=fLocal.map((v,i)=>v+eq[i]);
+        if(rel.kx1===0) fAdj[0]=0;
+        if(rel.ky1===0) fAdj[1]=0;
+        if(rel.cz1===0) fAdj[2]=0;
+        if(rel.kx2===0) fAdj[3]=0;
+        if(rel.ky2===0) fAdj[4]=0;
+        if(rel.cz2===0) fAdj[5]=0;
         // Use a standard sign convention where positive internal forces
         // correspond to positive diagrams without extra sign inversions
         const N1=fAdj[0], N2=-fAdj[3];

--- a/test/test.js
+++ b/test/test.js
@@ -109,3 +109,18 @@ function close(actual, expected, tol, msg){
   assert(Math.abs(shear[0])<1e-6 && Math.abs(shear[2]-1)<1e-6,'shear diagram');
   assert(Math.abs(moment[0]-0.25)<1e-6 && Math.abs(moment[2]-0.25)<1e-6,'moment diagram');
 })();
+
+// Moment release at beam start
+(function testMomentRelease(){
+  const frame={
+    nodes:[{x:0,y:0},{x:1,y:0}],
+    beams:[{n1:0,n2:1,cz1:0}],
+    supports:[{node:0,fixX:true,fixY:true},{node:1,fixY:true}],
+    loads:[],
+    memberPointLoads:[{beam:0,x:0.5,Fy:-1}]
+  };
+  const res=computeFrameResults(frame);
+  const diags=computeFrameDiagrams(frame,res,1);
+  const startMoment=diags[0].moment[0].y;
+  assert(Math.abs(startMoment) < 1e-6, 'moment at hinge not zero');
+})();


### PR DESCRIPTION
## Summary
- enforce hinge releases in `computeFrameDiagrams`
- test moment release behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: lockfile missing)*
- `npm install` *(fails: blocked downloading Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6866916edb708320b43b7108217884cc