### PR TITLE
Fix distributed load orientation handling

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -124,3 +124,18 @@ function close(actual, expected, tol, msg){
   const startMoment=diags[0].moment[0].y;
   assert(Math.abs(startMoment) < 1e-6, 'moment at hinge not zero');
 })();
+
+// Uniform load on inclined member
+(function testInclinedUniform(){
+  const L = Math.sqrt(2);
+  const frame={
+    nodes:[{x:0,y:0},{x:1,y:1}],
+    beams:[{n1:0,n2:1}],
+    supports:[{node:0,fixX:true,fixY:true,fixRot:true},{node:1,fixX:true,fixY:true,fixRot:true}],
+    loads:[],
+    memberLineLoads:[{beam:0,start:0,end:L,wY1:-1,wY2:-1}]
+  };
+  const res=computeFrameResults(frame);
+  close(res.reactions[1], L/2, 1e-6, 'left vertical reaction');
+  close(res.reactions[4], L/2, 1e-6, 'right vertical reaction');
+})();


### PR DESCRIPTION
## Summary
- correctly transform uniform line loads for any member angle
- default undefined load components to zero when splitting segments
- add helper to compute fixed-end forces for uniform loads
- test inclined member reactions

## Testing
- `npm ci` *(fails: lockfile missing)*
- `npm install` *(fails: puppeteer download blocked)*
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6867757e6ddc8320812751d7913104f0