### PR TITLE
Fix frame diagram sign convention

### DIFF
--- a/index.html
+++ b/index.html
@@ -1978,7 +1978,9 @@ function drawFrame(res,diags){
             const vals=diags[i][type];
             const path=new framePaper.Path({strokeColor:'red', fillColor:'rgba(255,0,0,0.3)'});
             path.add(p1);
-            const sign = dir.x >= 0 ? -1 : 1; // draw diagram on tension side
+            // Internal forces are already adjusted for sign, so always draw on
+            // the tension side of the member.
+            const sign = 1;
             vals.forEach((pt,j)=>{
                 const t=j/(vals.length-1);
                 const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);

--- a/solver.js
+++ b/solver.js
@@ -739,7 +739,11 @@ function computeFrameDiagrams(frame, res, divisions = 10) {
                 momentArr.push({x: x2, y: moment});
             });
         }
-        diags.push({ shear: shearArr, moment: momentArr, normal: normalArr });
+        // Flip shear and moment so downward shear is negative and sagging
+        // moment is positive, matching the beam diagram convention.
+        const shearAdj = shearArr.map(p => ({ x: p.x, y: -p.y }));
+        const momentAdj = momentArr.map(p => ({ x: p.x, y: -p.y }));
+        diags.push({ shear: shearAdj, moment: momentAdj, normal: normalArr });
     });
     return diags;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -106,8 +106,8 @@ function close(actual, expected, tol, msg){
   const diags=computeFrameDiagrams(frame,res,1);
   const shear=diags[0].shear.map(p=>p.y);
   const moment=diags[0].moment.map(p=>p.y);
-  assert(Math.abs(shear[0]-1)<1e-4 && Math.abs(shear[2]-2)<1e-4,'shear diagram');
-  assert(Math.abs(moment[0]-0.5)<1e-4 && Math.abs(moment[2]-1)<1e-4,'moment diagram');
+  assert(Math.abs(shear[0]+1)<1e-4 && Math.abs(shear[2]+2)<1e-4,'shear diagram');
+  assert(Math.abs(moment[0]+0.5)<1e-4 && Math.abs(moment[2]+1)<1e-4,'moment diagram');
 })();
 
 // Moment release at beam start
@@ -122,7 +122,7 @@ function close(actual, expected, tol, msg){
   const res=computeFrameResults(frame);
   const diags=computeFrameDiagrams(frame,res,1);
   const startMoment=diags[0].moment[0].y;
-  assert(Math.abs(startMoment-0.125) < 1e-6, 'moment value mismatch');
+  assert(Math.abs(startMoment+0.125) < 1e-6, 'moment value mismatch');
 })();
 
 // Uniform load on inclined member


### PR DESCRIPTION
## Summary
- adjust sign for shear and moment in `computeFrameDiagrams`
- always draw frame diagrams with `sign = 1`
- update unit tests to match sign convention

## Testing
- `npm run lint`
- `npm run lint:strict`
- `npm test`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: missing package-lock.json)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68682b4adf408320829c4407e60f0f4d