### PR TITLE
Fix frame diagram sign handling

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -739,11 +739,9 @@ function computeFrameDiagrams(frame, res, divisions = 10) {
                 momentArr.push({x: x2, y: moment});
             });
         }
-        // Flip shear and moment so downward shear is negative and sagging
-        // moment is positive, matching the beam diagram convention.
-        const shearAdj = shearArr.map(p => ({ x: p.x, y: -p.y }));
-        const momentAdj = momentArr.map(p => ({ x: p.x, y: -p.y }));
-        diags.push({ shear: shearAdj, moment: momentAdj, normal: normalArr });
+        // Shear and moment arrays are already in the conventional sign
+        // orientation, so they can be pushed directly without adjustment.
+        diags.push({ shear: shearArr, moment: momentArr, normal: normalArr });
     });
     return diags;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -106,8 +106,8 @@ function close(actual, expected, tol, msg){
   const diags=computeFrameDiagrams(frame,res,1);
   const shear=diags[0].shear.map(p=>p.y);
   const moment=diags[0].moment.map(p=>p.y);
-  assert(Math.abs(shear[0]-1)<1e-4 && Math.abs(shear[2]-2)<1e-4,'shear diagram');
-  assert(Math.abs(moment[0]+0.5)<1e-4 && Math.abs(moment[2]-0)<1e-4,'moment diagram');
+  assert(Math.abs(shear[0]+1)<1e-4 && Math.abs(shear[2]+2)<1e-4,'shear diagram');
+  assert(Math.abs(moment[0]-0.5)<1e-4 && Math.abs(moment[2]-0)<1e-4,'moment diagram');
 })();
 
 // Moment release at beam start
@@ -122,7 +122,7 @@ function close(actual, expected, tol, msg){
   const res=computeFrameResults(frame);
   const diags=computeFrameDiagrams(frame,res,1);
   const startMoment=diags[0].moment[0].y;
-  assert(Math.abs(startMoment+0.125) < 1e-6, 'moment value mismatch');
+  assert(Math.abs(startMoment-0.125) < 1e-6, 'moment value mismatch');
 })();
 
 // Uniform load on inclined member


### PR DESCRIPTION
## Summary
- correct sign processing in frame diagrams
- update unit tests for new sign convention

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686abe6ce00c83209cd86086c163d2b7