### PR TITLE
Update frame tab units to kN

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@
                     </svg>
                     <div id="frameMemberLineLoads"></div>
                     <button onclick="addFrameMemberLineLoad()">Add Line Load</button>
+                    <div id="frameWarningMsg" style="color:red;font-weight:bold;"></div>
                 </div>
                 <div class="section">
                     <h2>Support Reactions</h2>
@@ -1485,6 +1486,34 @@ function mulMV(A,x){
     return A.map(r=>r.reduce((s,v,i)=>s+v*x[i],0));
 }
 
+function frameMemberLoadsOutOfRange(){
+    for(const l of frameState.memberPointLoads){
+        const b=frameState.beams[l.beam];
+        if(!b) continue;
+        const n1=frameState.nodes[b.n1];
+        const n2=frameState.nodes[b.n2];
+        if(!n1||!n2) continue;
+        const L=Math.hypot(n2.x-n1.x,n2.y-n1.y);
+        if(l.x<0 || l.x>L) return true;
+    }
+    for(const l of frameState.memberLineLoads){
+        const b=frameState.beams[l.beam];
+        if(!b) continue;
+        const n1=frameState.nodes[b.n1];
+        const n2=frameState.nodes[b.n2];
+        if(!n1||!n2) continue;
+        const L=Math.hypot(n2.x-n1.x,n2.y-n1.y);
+        if(l.start<0 || l.end> L) return true;
+    }
+    return false;
+}
+
+function updateFrameWarning(){
+    const el=document.getElementById('frameWarningMsg');
+    if(!el) return;
+    el.textContent=frameMemberLoadsOutOfRange()? 'Warning: some member loads are outside the beam length.' : '';
+}
+
 function addFrameBeam(){
     const first=Object.keys(crossSections)[0]||'';
     const idx=frameState.beams.length+1;
@@ -1623,7 +1652,7 @@ function rebuildFrameMemberPointLoads(){
     const c=document.getElementById('frameMemberPointLoads');
     c.innerHTML='';
     frameState.memberPointLoads.forEach((l,i)=>{
-        const opts=frameState.beams.map((b,j)=>`<option value="${j}"${j===l.beam?' selected':''}>${j}</option>`).join('');
+        const opts=frameState.beams.map((b,j)=>`<option value="${j}"${j===l.beam?' selected':''}>${b.name||j}</option>`).join('');
         const row=document.createElement('div');
         row.className='input-row frame-row';
         row.innerHTML=`<label>Load ${i+1}</label>`+
@@ -1654,7 +1683,7 @@ function rebuildFrameMemberLineLoads(){
     const c=document.getElementById('frameMemberLineLoads');
     c.innerHTML='';
     frameState.memberLineLoads.forEach((l,i)=>{
-        const opts=frameState.beams.map((b,j)=>`<option value="${j}"${j===l.beam?' selected':''}>${j}</option>`).join('');
+        const opts=frameState.beams.map((b,j)=>`<option value="${j}"${j===l.beam?' selected':''}>${b.name||j}</option>`).join('');
         const row=document.createElement('div');
         row.className='input-row frame-row';
         row.innerHTML=`<label>Line ${i+1}</label>`+
@@ -1701,13 +1730,14 @@ function solveFrame(){
             kx1:b.kx1,ky1:b.ky1,cz1:b.cz1,kx2:b.kx2,ky2:b.ky2,cz2:b.cz2,on:b.on};
     });
     const supports=frameState.supports.map(s=>({node:s.node,fixX:s.fixX,fixY:s.fixY,fixRot:s.fixRot}));
-    const loads=frameState.loads.map(l=>({node:l.node,Px:l.Fx||0,Py:l.Fz||0,Mz:l.My||0}));
-    const mPoint=frameState.memberPointLoads.map(l=>({beam:l.beam,x:l.x,Fx:l.Fx||0,Fy:l.Fy||0,Mz:l.Mz||0}));
-    const mLine=frameState.memberLineLoads.map(l=>({beam:l.beam,start:l.start,end:l.end,wX1:l.wX1||0,wX2:l.wX2||0,wY1:l.wY1||0,wY2:l.wY2||0}));
+    const loads=frameState.loads.map(l=>({node:l.node,Px:(l.Fx||0)*1000,Py:(l.Fz||0)*1000,Mz:(l.My||0)*1000}));
+    const mPoint=frameState.memberPointLoads.map(l=>({beam:l.beam,x:l.x,Fx:(l.Fx||0)*1000,Fy:(l.Fy||0)*1000,Mz:(l.Mz||0)*1000}));
+    const mLine=frameState.memberLineLoads.map(l=>({beam:l.beam,start:l.start,end:l.end,wX1:(l.wX1||0)*1000,wX2:(l.wX2||0)*1000,wY1:(l.wY1||0)*1000,wY2:(l.wY2||0)*1000}));
     const frame={nodes:frameState.nodes,beams,supports,loads,memberPointLoads:mPoint,memberLineLoads:mLine,E:state.E};
     const res=computeFrameResults(frame);
     if(!res) return;
     updateFrameReactions(res);
+    updateFrameWarning();
     const div=parseInt(document.getElementById('frameDiv')?.value||'1');
     const diags=computeFrameDiagrams(frame,res,div);
     frameRes=res;
@@ -1721,16 +1751,16 @@ function updateFrameReactions(res){
     const table=document.getElementById('frameSupportReactions');
     if(!table){return;}
     if(!res){table.innerHTML='';return;}
-    let html='<table><thead><tr><th>Support</th><th>Node</th><th>Rx (N)</th><th>Ry (N)</th><th>Rz (N·m)</th></tr></thead><tbody>';
+    let html='<table><thead><tr><th>Support</th><th>Node</th><th>Rx (kN)</th><th>Ry (kN)</th><th>Rz (kN·m)</th></tr></thead><tbody>';
     let sumX=0,sumY=0,sumZ=0;
     frameState.supports.forEach((s,i)=>{
         const rx=s.fixX?res.reactions[3*s.node]:0;
         const ry=s.fixY?res.reactions[3*s.node+1]:0;
         const rz=s.fixRot?res.reactions[3*s.node+2]:0;
         sumX+=rx; sumY+=ry; sumZ+=rz;
-        html+=`<tr><td>${i+1}</td><td>${s.node}</td><td>${rx.toFixed(1)}</td><td>${ry.toFixed(1)}</td><td>${rz.toFixed(1)}</td></tr>`;
+        html+=`<tr><td>${i+1}</td><td>${s.node}</td><td>${(rx/1000).toFixed(2)}</td><td>${(ry/1000).toFixed(2)}</td><td>${(rz/1000).toFixed(2)}</td></tr>`;
     });
-    html+=`<tr><th colspan="2">Sum</th><th>${sumX.toFixed(1)}</th><th>${sumY.toFixed(1)}</th><th>${sumZ.toFixed(1)}</th></tr>`;
+    html+=`<tr><th colspan="2">Sum</th><th>${(sumX/1000).toFixed(2)}</th><th>${(sumY/1000).toFixed(2)}</th><th>${(sumZ/1000).toFixed(2)}</th></tr>`;
     html+='</tbody></table>';
     table.innerHTML=html;
 }
@@ -1967,7 +1997,7 @@ function drawFrame(res,diags){
         const type=document.getElementById('frameDiagSelect').value;
         let maxVal=0;
         diags.forEach(d=>{d[type].forEach(pt=>{maxVal=Math.max(maxVal,Math.abs(pt.y));});});
-        const diagScale=30/(maxVal||1);
+        const diagScale=30/((maxVal/1000)||1);
         frameState.beams.forEach((b,i)=>{
             const n1=frameState.nodes[b.n1];
             const n2=frameState.nodes[b.n2];
@@ -1984,15 +2014,15 @@ function drawFrame(res,diags){
             vals.forEach((pt,j)=>{
                 const t=j/(vals.length-1);
                 const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
-                path.add(base.add(perp.multiply(pt.y*diagScale*sign)));
+                path.add(base.add(perp.multiply((pt.y/1000)*diagScale*sign)));
             });
             path.add(p2);
             path.closed=true;
             vals.forEach((pt,j)=>{
                 const t=j/(vals.length-1);
                 const base=toPoint(n1.x+(n2.x-n1.x)*t,n1.y+(n2.y-n1.y)*t);
-                const labelPos=base.add(perp.multiply(pt.y*diagScale*sign+10));
-                new framePaper.PointText({point:labelPos, content:pt.y.toFixed(1), fontSize:10});
+                const labelPos=base.add(perp.multiply((pt.y/1000)*diagScale*sign+10));
+                new framePaper.PointText({point:labelPos, content:(pt.y/1000).toFixed(2), fontSize:10});
             });
         });
     }


### PR DESCRIPTION
## Summary
- display support reactions in kN and kNm
- convert frame loads entered in kN/kNm to solver units
- flag member loads that extend beyond the beam length
- show beam names in member load dropdowns
- scale frame diagrams using kN/kNm

## Testing
- `npm ci` *(fails: missing lockfile)*
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test` *(fails: shear diagram assertion)*
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: missing Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686ba5a4a76883208712b42b12bc343a