### PR TITLE
Fix frame canvas sizing and arrow orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
         .frame-row .cell select { width:70px; }
         #frameLayout { display:flex; flex-wrap:wrap; gap:20px; align-items:flex-start; }
         #frameControls { flex:1 1 100%; max-width:none; }
-        #frameDiagram { flex:2 1 400px; min-height:520px; max-width:650px; }
-        #frameDiagram canvas { width:100%; height:100%; max-width:650px; max-height:650px; }
+        #frameDiagram { flex:2 1 400px; min-height:520px; }
+        #frameDiagram canvas { width:100%; height:100%; }
         #frameToolbar { display:flex; gap:8px; margin-bottom:8px; align-items:center; }
     </style>
 </head>
@@ -1773,9 +1773,8 @@ function updateFrameReactions(res){
 
 function drawFrame(res,diags){
     const canvas = document.getElementById('frameCanvas');
-    const maxSize = 650;
-    const cW = Math.min(canvas.clientWidth || maxSize, maxSize);
-    const cH = Math.min(canvas.clientHeight || maxSize, maxSize);
+    const cW = canvas.clientWidth || 650;
+    const cH = canvas.clientHeight || 650;
     canvas.width = cW;
     canvas.height = cH;
     if(!framePaper){
@@ -1960,9 +1959,9 @@ function drawFrame(res,diags){
                 const end=toPoint(ex,ey);
                 new framePaper.Path({segments:[end,base], strokeColor:'blue', strokeWidth:2});
                 const vec=base.subtract(end).normalize();
-                const left=end.add(vec.rotate(30).multiply(6));
-                const right=end.add(vec.rotate(-30).multiply(6));
-                new framePaper.Path({segments:[left,end,right], strokeColor:'blue', fillColor:'blue', strokeWidth:2});
+                const left=base.add(vec.rotate(30).multiply(6));
+                const right=base.add(vec.rotate(-30).multiply(6));
+                new framePaper.Path({segments:[left,base,right], strokeColor:'blue', fillColor:'blue', strokeWidth:2});
             }
         });
     }


### PR DESCRIPTION
## Summary
- expand frame canvas to use all available width
- remove width cap so large screens are fully utilized
- point line load arrows directly at the beam

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: package-lock.json missing)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e33b5d4388320b9d30dfbf8f9183c