### PR TITLE
Add linear buckling analysis option

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,10 @@
                     <select id="frameAnalysisType" onchange="solveFrame()">
                         <option value="first">1st order analysis</option>
                         <option value="pdelta">P-Delta</option>
+                        <option value="lba">Linear buckling</option>
                     </select>
+                    <select id="lbaModeSelect" style="display:none;" onchange="solveFrame()"></select>
+                    <span id="lbaAlpha" style="margin-left:6px;font-size:12px;display:none;"></span>
                 </div>
                 <canvas id="frameCanvas" width="650" height="650" style="border:1px solid #ccc; width:100%; height:100%;"></canvas>
             </div>
@@ -1741,6 +1744,29 @@ function solveFrame(){
     const mLine=frameState.memberLineLoads.map(l=>({beam:l.beam,start:l.start,end:l.end,wX1:(l.wX1||0)*1000,wX2:(l.wX2||0)*1000,wY1:(l.wY1||0)*1000,wY2:(l.wY2||0)*1000}));
     const frame={nodes:frameState.nodes,beams,supports,loads,memberPointLoads:mPoint,memberLineLoads:mLine,E:state.E};
     const analysis=document.getElementById('frameAnalysisType')?.value||'first';
+    const modeSel=document.getElementById('lbaModeSelect');
+    const alphaEl=document.getElementById('lbaAlpha');
+    if(analysis==='lba'){
+        modeSel.style.display='inline-block';
+        alphaEl.style.display='inline-block';
+        const mode=parseInt(modeSel.value||'1')-1;
+        const res=computeFrameResultsLBA(frame,mode);
+        if(!res) return;
+        if(modeSel.options.length!==res.modes.length){
+            modeSel.innerHTML=res.modes.map((_,i)=>`<option value="${i+1}">Mode ${i+1}</option>`).join('');
+            modeSel.value=String(mode+1);
+        }
+        alphaEl.innerHTML=`α<sub>cr</sub> = ${res.alpha.toFixed(2)}`;
+        frameRes=res;
+        frameDiags=[];
+        drawFrame(res,[]);
+        updateFrameReactions(null);
+        updateFrameWarning();
+        return;
+    } else {
+        if(modeSel){modeSel.style.display='none';}
+        if(alphaEl){alphaEl.style.display='none';alphaEl.innerHTML='';}
+    }
     const res=analysis==='pdelta'?computeFrameResultsPDelta(frame):computeFrameResults(frame);
     if(!res) return;
     updateFrameReactions(res);

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "eslint": "^8.56.0",
     "puppeteer": "^24.11.0"
+  },
+  "dependencies": {
+    "ml-matrix": "^6.12.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {computeResults, computeSectionDesign, computeFrameResults, computeFrameResultsPDelta, computeFrameDiagrams} = require('../solver');
+const {computeResults, computeSectionDesign, computeFrameResults, computeFrameResultsPDelta, computeFrameResultsLBA, computeFrameDiagrams} = require('../solver');
 
 function close(actual, expected, tol, msg){
   if(Math.abs(actual-expected) > tol) throw new Error(msg+` expected ${expected} got ${actual}`);
@@ -153,4 +153,17 @@ function close(actual, expected, tol, msg){
   const first=computeFrameResults(frame);
   const second=computeFrameResultsPDelta(frame);
   assert(Math.abs(second.displacements[3])>Math.abs(first.displacements[3]),'P-Delta should increase sway');
+})();
+
+// Basic LBA test
+(function testLBA(){
+  const frame={
+    nodes:[{x:0,y:0},{x:0,y:1}],
+    beams:[{n1:0,n2:1}],
+    supports:[{node:0,fixX:true,fixY:true,fixRot:true},{node:1,fixX:true}],
+    loads:[{node:1,Py:-1000}]
+  };
+  const res=computeFrameResultsLBA(frame,0);
+  assert(res.alpha>1000,'alpha magnitude');
+  assert(res.displacements.length===6,'mode displacement size');
 })();


### PR DESCRIPTION
## Summary
- add Linear Buckling Analysis (LBA) option to the frame toolbar
- display available buckling modes with alpha_cr values
- implement computation of buckling modes in solver
- expose new API functions to the browser and tests
- include `ml-matrix` dependency for eigenvalue solving
- add unit test for the new analysis type

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm ci` *(fails without this env var)*
- `npm test`
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686f8dd143ac83209f8e53b4d2cd81bb