### PR TITLE
Fix ml-matrix loading in browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.15/paper-full.min.js"></script>
     <script src="./steel_cross_sections_data.js"></script>
     <script src="./timber_cross_sections_data.js"></script>
+    <script src="./node_modules/ml-matrix/matrix.umd.js"></script>
     <script src="./solver.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" defer></script>
     <script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "node test/test.js",
     "lint": "eslint .",
     "test:integration": "node test/integration.js",
-    "lint:strict": "eslint .",
+    "lint:strict": "eslint . --rule 'no-use-before-define:error' --rule 'no-undef:error'",
     "test:smoke": "node ./scripts/run-smoke-tests.js"
   },
   "devDependencies": {

--- a/solver.js
+++ b/solver.js
@@ -826,7 +826,10 @@ function computeFrameBucklingModes(frame, numModes = 10) {
     });
     const { Kmod, indices } = applyBC(K, new Array(dof).fill(0), fixed);
     const Kgmod = indices.map(i => indices.map(j => Kg[i][j]));
-    const { Matrix, EigenvalueDecomposition, inverse } = require('ml-matrix');
+    const { Matrix, EigenvalueDecomposition, inverse } =
+        typeof require !== 'undefined'
+            ? require('ml-matrix')
+            : globalThis.mlMatrix;
     const ev = new EigenvalueDecomposition(inverse(new Matrix(Kmod)).mmul(new Matrix(Kgmod)));
     const vals = Array.from(ev.realEigenvalues);
     const vecs = ev.eigenvectorMatrix.to2DArray();


### PR DESCRIPTION
## Summary
- load ml-matrix directly in the browser
- add strict lint rules to package.json

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*
- `npm ci` *(fails: no package-lock)*

------
https://chatgpt.com/codex/tasks/task_e_686f93186ba883208151ecece3ae6a16