### PR TITLE
Fix LBA mode order and support zero deflection scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
             <div id="frameDiagram" class="section">
                 <div id="frameToolbar">
                     <label>Deflection scale</label>
-                    <input type="range" id="frameDefScale" min="0.1" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
+                    <input type="range" id="frameDefScale" min="0" max="10" step="0.1" value="1" oninput="drawFrame(frameRes,frameDiags)">
                     <div id="frameMaxDisp" style="font-size:12px;margin-top:4px;"></div>
                     <label style="margin-left:10px;">Member division</label>
                     <input type="number" id="frameDiv" value="10" min="1" step="1" onchange="solveFrame()" style="width:60px;">
@@ -1757,7 +1757,8 @@ function solveFrame(){
             modeSel.innerHTML=res.modes.map((_,i)=>`<option value="${i+1}">Mode ${i+1}</option>`).join('');
             modeSel.value=String(mode+1);
         }
-        alphaEl.innerHTML=`α<sub>cr</sub> = ${res.alpha.toFixed(2)}`;
+        const beta = 1 / (1 - 1 / res.alpha);
+        alphaEl.innerHTML=`α<sub>cr</sub> = ${res.alpha.toFixed(2)} (β = ${beta.toFixed(2)})`;
         frameRes=res;
         frameDiags=[];
         drawFrame(res,[]);
@@ -1998,7 +1999,7 @@ function drawFrame(res,diags){
     if(res){
         const scaleInput=document.getElementById('frameDefScale');
         const userVal=scaleInput?parseFloat(scaleInput.value||'1'):1;
-        const defScale=Math.max(userVal,0.1);
+        const defScale=userVal;
         const dispScale=40*defScale;
         const mags=frameState.nodes.map((_,i)=>{
             const ux=res.displacements[3*i];

--- a/solver.js
+++ b/solver.js
@@ -833,7 +833,10 @@ function computeFrameBucklingModes(frame, numModes = 10) {
     const ev = new EigenvalueDecomposition(inverse(new Matrix(Kmod)).mmul(new Matrix(Kgmod)));
     const vals = Array.from(ev.realEigenvalues);
     const vecs = ev.eigenvectorMatrix.to2DArray();
-    const order = vals.map((v, i) => ({ v, i })).filter(o => o.v > 1e-8).sort((a, b) => a.v - b.v).slice(0, numModes);
+    const order = vals.map((v, i) => ({ v, i }))
+        .filter(o => o.v > 1e-8)
+        .sort((a, b) => b.v - a.v)
+        .slice(0, numModes);
     const alphas = order.map(o => 1 / o.v);
     const vectors = order.map(o => vecs.map(r => r[o.i]));
     return { alphas, vectors, indices };

--- a/test/test.js
+++ b/test/test.js
@@ -166,4 +166,7 @@ function close(actual, expected, tol, msg){
   const res=computeFrameResultsLBA(frame,0);
   assert(res.alpha>1000,'alpha magnitude');
   assert(res.displacements.length===6,'mode displacement size');
+  for(let i=1;i<res.modes.length;i++){
+    assert(res.modes[i]>=res.modes[i-1],'modes sorted');
+  }
 })();


### PR DESCRIPTION
## Summary
- allow frame deformation scale slider to reach zero
- show the moment magnification factor β with αcr
- sort LBA buckling modes by αcr ascending
- verify LBA mode order in tests

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686f9bd652d483208d162e9befe28b2a