### PR TITLE
Normalize LBA output and adjust frame diagram width

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
         .frame-row .cell select { width:70px; }
         #frameLayout { display:flex; flex-wrap:wrap; gap:20px; align-items:flex-start; }
         #frameControls { flex:1 1 100%; max-width:none; }
-        #frameDiagram { flex:2 1 400px; min-height:520px; max-width:650px; }
-        #frameDiagram canvas { width:100%; height:100%; max-width:650px; max-height:650px; }
+        #frameDiagram { flex:2 1 400px; min-height:520px; max-width:800px; }
+        #frameDiagram canvas { width:100%; height:100%; max-width:800px; max-height:650px; }
         #frameToolbar { display:flex; gap:8px; margin-bottom:8px; align-items:center; }
     </style>
 </head>
@@ -341,7 +341,7 @@
                     <select id="lbaModeSelect" style="display:none;" onchange="solveFrame()"></select>
                     <span id="lbaAlpha" style="margin-left:6px;font-size:12px;display:none;"></span>
                 </div>
-                <canvas id="frameCanvas" width="650" height="650" style="border:1px solid #ccc; width:100%; height:100%;"></canvas>
+                <canvas id="frameCanvas" width="800" height="650" style="border:1px solid #ccc; width:100%; height:100%;"></canvas>
             </div>
         </div>
     </div> <!-- end frameTab -->
@@ -1802,7 +1802,7 @@ function updateFrameReactions(res){
 
 function drawFrame(res,diags){
     const canvas = document.getElementById('frameCanvas');
-    const maxSize = 650;
+    const maxSize = 800;
     const cW = Math.min(canvas.clientWidth || maxSize, maxSize);
     const cH = Math.min(canvas.clientHeight || maxSize, maxSize);
     canvas.width = cW;

--- a/solver.js
+++ b/solver.js
@@ -849,6 +849,10 @@ function computeFrameResultsLBA(frame, mode = 0) {
     const dof = frame.nodes.length * 3;
     const disp = new Array(dof).fill(0);
     res.indices.forEach((idx, i) => { disp[idx] = res.vectors[m][i]; });
+    const maxAbs = Math.max(...disp.map(v => Math.abs(v)));
+    if (maxAbs > 0) {
+        for (let i = 0; i < disp.length; i++) disp[i] /= maxAbs;
+    }
     return { displacements: disp, alpha: res.alphas[m], modes: res.alphas };
 }
 


### PR DESCRIPTION
## Summary
- scale LBA mode shapes so maximum deflection equals `1`
- increase frame diagram max width to fit extra controls

## Testing
- `npm ci` *(fails: package-lock.json missing)*
- `npm install` *(fails: puppeteer download blocked)*
- `npm test` *(fails: cannot find module 'ml-matrix')*
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_686f9e64fcb88320aee24d5404f6179f