### PR TITLE
Fix frame mode shape normalization

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -851,7 +851,7 @@ function computeFrameResultsLBA(frame, mode = 0) {
     res.indices.forEach((idx, i) => { disp[idx] = res.vectors[m][i]; });
     const maxAbs = Math.max(...disp.map(v => Math.abs(v)));
     if (maxAbs > 0) {
-        for (let i = 0; i < disp.length; i++) disp[i] /= maxAbs;
+        for (let i = 0; i < disp.length; i++) disp[i] = (disp[i] / maxAbs) / 1000;
     }
     return { displacements: disp, alpha: res.alphas[m], modes: res.alphas };
 }


### PR DESCRIPTION
## Summary
- normalize frame buckling mode displacements to 1 mm

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686fa283d1908320a5840792f9bccc05