### PR TITLE
Switch to geometric stiffness P-Δ solver

### DIFF
--- a/index.html
+++ b/index.html
@@ -1769,7 +1769,7 @@ function solveFrame(){
         if(modeSel){modeSel.style.display='none';}
         if(alphaEl){alphaEl.style.display='none';alphaEl.innerHTML='';}
     }
-    const res=analysis==='pdelta'?computeFrameResultsPDelta(frame):computeFrameResults(frame);
+    const res=analysis==='pdelta'?computeFrameResultsPDelta_Kg(frame):computeFrameResults(frame);
     if(!res) return;
     updateFrameReactions(res);
     updateFrameWarning();

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {computeResults, computeSectionDesign, computeFrameResults, computeFrameResultsPDelta, computeFrameResultsLBA, computeFrameDiagrams} = require('../solver');
+const {computeResults, computeSectionDesign, computeFrameResults, computeFrameResultsPDelta_Kg, computeFrameResultsLBA, computeFrameDiagrams} = require('../solver');
 
 function close(actual, expected, tol, msg){
   if(Math.abs(actual-expected) > tol) throw new Error(msg+` expected ${expected} got ${actual}`);
@@ -151,7 +151,7 @@ function close(actual, expected, tol, msg){
     loads:[{node:1,Px:1000,Py:-10000}]
   };
   const first=computeFrameResults(frame);
-  const second=computeFrameResultsPDelta(frame);
+  const second=computeFrameResultsPDelta_Kg(frame);
   assert(Math.abs(second.displacements[3])>Math.abs(first.displacements[3]),'P-Delta should increase sway');
 })();
 


### PR DESCRIPTION
## Summary
- forward all release parameters to `frameElementWithReleases`
- add helpers for geometric-stiffness iteration
- implement `computeFrameResultsPDelta_Kg` and use it throughout
- update unit tests to use the new solver

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686fb1b257f08320aa7c33d32b2254b5