### PR TITLE
Fix P-Delta diagrams

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -814,7 +814,9 @@ function computeFrameResultsPDelta(frame, opts={}) {
             if (maxDiff < tol * height) {
                 const finalFrame = JSON.parse(JSON.stringify(base));
                 if (newExtra.length) finalFrame.loads = (finalFrame.loads || []).concat(newExtra);
-                return computeFrameResults(finalFrame);
+                const finalRes = computeFrameResults(finalFrame);
+                const diagrams = computeFrameDiagrams(finalFrame, finalRes, 1);
+                return { ...finalRes, diagrams };
             }
         }
 
@@ -823,7 +825,9 @@ function computeFrameResultsPDelta(frame, opts={}) {
     }
     const finalFrame = JSON.parse(JSON.stringify(base));
     if (extra.length) finalFrame.loads = (finalFrame.loads || []).concat(extra);
-    return computeFrameResults(finalFrame);
+    const finalRes = computeFrameResults(finalFrame);
+    const diagrams = computeFrameDiagrams(finalFrame, finalRes, 1);
+    return { ...finalRes, diagrams };
 }
 
 function geometricStiffnessMatrix(N, L) {
@@ -947,7 +951,8 @@ function computeFrameResultsPDelta_Kg(baseFrame, opts = {}) {
         for (let i = 0; i < dof; i++) maxDiff = Math.max(maxDiff, Math.abs(u[i] - uPrev[i]));
         if (maxDiff < tol) {
             const reactions = multiplyMatrixVector(Ktot, u).map((v, i) => v - F[i]);
-            return { displacements: u, reactions };
+            const diagrams = computeFrameDiagrams(frame, { displacements: u }, 1);
+            return { displacements: u, reactions, diagrams };
         }
 
         uPrev = u.slice();
@@ -955,7 +960,8 @@ function computeFrameResultsPDelta_Kg(baseFrame, opts = {}) {
     }
     console.warn('P-Δ Newton loop did not converge');
     const reactions = multiplyMatrixVector(Klin, uPrev).map((v, i) => v - F[i]);
-    return { displacements: uPrev, reactions };
+    const diagrams = computeFrameDiagrams(frame, { displacements: uPrev }, 1);
+    return { displacements: uPrev, reactions, diagrams };
 }
 
 function computeFrameBucklingModes(frame, numModes = 10) {

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,9 @@ function close(actual, expected, tol, msg){
   const first=computeFrameResults(frame);
   const second=computeFrameResultsPDelta_Kg(frame);
   assert(Math.abs(second.displacements[3])>Math.abs(first.displacements[3]),'P-Delta should increase sway');
+  const diag=second.diagrams || computeFrameDiagrams(frame,second,1);
+  const nonZero=diag[0].moment.some(pt=>Math.abs(pt.y)>1e-8);
+  assert(nonZero,'P-Delta diagrams should not be zero');
 })();
 
 // Basic LBA test


### PR DESCRIPTION
## Summary
- compute diagrams after solving the P-Δ system so results aren't empty
- verify diagrams are populated in unit tests

## Testing
- `npm ci` *(fails: missing package-lock)*
- `npm test` *(fails: Cannot find module 'ml-matrix')*
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_686fb9cee568832092eae655c07a79e3