### PR TITLE
Fix load condensation for released members

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -124,7 +124,7 @@ function close(actual, expected, tol, msg){
   const res=computeFrameResults(frame);
   const diags=computeFrameDiagrams(frame,res,1);
   const startMoment=diags[0].moment[0].y;
-  assert(Math.abs(startMoment-0.125) < 1e-6, 'moment value mismatch');
+  assert(Math.abs(startMoment-0) < 1e-6, 'moment value mismatch');
 })();
 
 // Uniform load on inclined member


### PR DESCRIPTION
## Summary
- add `condenseLoadVector` helper
- apply condensation to member point and line loads
- update diagrams load handling
- adjust unit test for released moment

## Testing
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm test` *(fails: Cannot find module 'ml-matrix')*
- `npm run test:smoke` *(fails: Cannot find module 'puppeteer')*
- `npm ci` *(fails: requires package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2fe15788320853fa2d32abfad3e