### PR TITLE
Fix retained load handling in condenseLoadVector

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -121,6 +121,7 @@ function condenseLoadVector(KbbInv, Kbn, fFull){
     }
     const fCond = new Array(6).fill(0);
     for (let i = 0; i < 6; i++) {
+        fCond[i] = fFull[i];
         let sum = 0;
         for (let j = 0; j < 6; j++) sum += Kbn[i][j] * temp[j];
         fCond[i] -= sum;


### PR DESCRIPTION
## Summary
- correctly include loads on retained DOFs in `condenseLoadVector`

## Testing
- `npm ci`
- `npm test` *(fails: shear diagram assertion)*
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: page.waitForTimeout is not a function; cdn requests blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687360c505248320961fdcd7a5bf2433