### PR TITLE
Fix boundary condition handling in P-Delta solver

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -958,7 +958,7 @@ function computeFrameResultsPDelta_Kg(baseFrame, opts = {}) {
     const Klin = assembleLinearK(frame);
     const F = buildGlobalLoadVector(frame);
     const fixed = collectFixedDOFs(frame);
-    applyBC(Klin, F, fixed);
+    const { Kmod: KlinRed, Fmod } = applyBC(Klin, F, fixed);
 
     let res = computeFrameResults(frame);
     let uPrev = res.displacements.slice();
@@ -987,9 +987,10 @@ function computeFrameResultsPDelta_Kg(baseFrame, opts = {}) {
                     Kg[dofs[i]][dofs[j]] += kgG[i][j];
         });
 
+        const KgRed = applyBC(Kg, F, fixed).Kmod;
         const Ktot = addMatrices(Klin, Kg);
-        const { Kmod } = applyBC(Ktot, F, fixed);
-        const uFree = gaussSolve(clone2D(Kmod), buildFmod(F, fixed));
+        const KtotRed = addMatrices(KlinRed, KgRed);
+        const uFree = gaussSolve(clone2D(KtotRed), Fmod);
         const u = restoreFullVector(uFree, fixed, dof);
 
         let maxDiff = 0;


### PR DESCRIPTION
## Summary
- computeFrameResultsPDelta_Kg now keeps the reduced linear stiffness
- use reduced matrices inside the Newton loop

## Testing
- `npm run lint:strict`
- `npm test` *(fails: shear diagram)*
- `npm run lint`
- `npm run test:integration`
- `npm run test:smoke` *(fails: page.waitForTimeout is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6873632a883083209f5afb0e754bc8ef