### PR TITLE
Fix cantilever moment diagram

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -756,7 +756,7 @@ function computeFrameDiagrams(frame, res, divisions = 10) {
         // --- FIX #2: Correct sign convention for internal forces ---
         const N1 = fFinalLocal[0], V1 = fFinalLocal[1], M1 = fFinalLocal[2], M2 = fFinalLocal[5];
         let normal = N1;
-        let shear = V1;        // use internal forces directly
+        let shear = -V1; // positive shear should decrease bending moment
         let moment = M1;
 
         const events = new Set([0, L]);

--- a/test/test.js
+++ b/test/test.js
@@ -108,7 +108,7 @@ function close(actual, expected, tol, msg){
   const moment=diags[0].moment.map(p=>p.y);
   const lastShear=shear[shear.length-1];
   const lastMoment=moment[moment.length-1];
-  assert(Math.abs(shear[0]-1)<1e-4 && Math.abs(lastShear-2)<1e-4,'shear diagram');
+  assert(Math.abs(shear[0]+1)<1e-4 && Math.abs(lastShear-0)<1e-4,'shear diagram');
   assert(Math.abs(moment[0]-0.5)<1e-4 && Math.abs(lastMoment-0)<1e-4,'moment diagram');
 })();
 


### PR DESCRIPTION
## Summary
- fix sign of shear for frame diagrams
- update tests for new sign convention

## Testing
- `npm test`
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: page.waitForTimeout is not a function and Chart/d3 are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873d3dc05dc8320b31b20dcc930a665