### PR TITLE
Fix doubled member loads in P‑Delta solver

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -977,10 +977,10 @@ function computeFrameResultsPDelta_Kg(baseFrame, opts = {}) {
     const Klin = assembleLinearK(frame);
     const F = buildGlobalLoadVector(frame);
     const fixed = collectFixedDOFs(frame);
-    applyBC(Klin, F, fixed);
-
-    let res = computeFrameResults(frame);
-    let uPrev = res.displacements.slice();
+    const {Kmod,Fmod} = applyBC(Klin, F, fixed);
+    const uFree0 = gaussSolve(clone2D(Kmod), Fmod);
+    let uPrev = restoreFullVector(uFree0, fixed, dof);
+    let res = { displacements: uPrev };
 
     for (let iter = 0; iter < maxIter; iter++) {
         const diags = computeFrameDiagrams(frame, res, 1);


### PR DESCRIPTION
## Summary
- avoid double-counting frame member loads in `computeFrameResultsPDelta_Kg`
- derive initial displacement from assembled stiffness and load vector

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Chart and d3 not defined; waitForTimeout is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6873e1701de88320a532588e09b9917a