### PR TITLE
Fix line load arrow orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2027,8 +2027,8 @@ function drawFrame(res,diags){
                 const loadVec=new framePaper.Point(wX,wY);
                 const mag=Math.hypot(wX,wY);
                 const addLen=20/scale;
-                const tailX=mag===0?bx:bx+loadVec.x/mag*(mag*forceScale + addLen);
-                const tailY=mag===0?by:by+loadVec.y/mag*(mag*forceScale + addLen);
+                const tailX=mag===0?bx:bx-loadVec.x/mag*(mag*forceScale + addLen);
+                const tailY=mag===0?by:by-loadVec.y/mag*(mag*forceScale + addLen);
                 const tip=toPoint(bx,by);
                 const tail=toPoint(tailX,tailY);
                 new framePaper.Path({segments:[tail,tip], strokeColor:'blue', strokeWidth:2});

--- a/scripts/run-smoke-tests.js
+++ b/scripts/run-smoke-tests.js
@@ -15,7 +15,11 @@ const puppeteer = require('puppeteer');
   });
   const filePath = `file://${process.cwd()}/index.html`;
   await page.goto(filePath);
-  await page.waitForTimeout(1000);
+  if (typeof page.waitForTimeout === 'function') {
+    await page.waitForTimeout(1000);
+  } else {
+    await new Promise(r => setTimeout(r, 1000));
+  }
   await browser.close();
   if (errorDetected) {
     console.error('Smoke test failed');


### PR DESCRIPTION
## Summary
- fix orientation of frame member line load arrows so negative loads point correctly
- make smoke test script compatible with Puppeteer 24

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Chart is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68773fe7d0888320b92f3b112d92e5d3