### PR TITLE
Fix member load handling with end releases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,8 @@ export default [
         require: 'readonly',
         module: 'readonly',
         process: 'readonly',
-        console: 'readonly'
+        console: 'readonly',
+        setTimeout: 'readonly'
       }
     },
     rules: {


### PR DESCRIPTION
## Summary
- allow setTimeout in lint config
- correct static condensation of loads when elements have end releases
- apply condensation inside global load assembly

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Chart and d3 not defined due to blocked CDN requests)*

------
https://chatgpt.com/codex/tasks/task_e_6877e72726c88320867d137c458c1470