### PR TITLE
Fix axial diagram updates

### DIFF
--- a/solver.js
+++ b/solver.js
@@ -835,7 +835,7 @@ function computeFrameDiagrams(frame, res, divisions = 10) {
             });
 
             const shear_at_x1 = shear;
-            normal -= intAx;
+            normal += intAx; // add axial contribution directly
             shear  -= intWy;
             moment += shear_at_x1 * dx - (intWyX - x1*intWy);
 
@@ -846,7 +846,7 @@ function computeFrameDiagrams(frame, res, divisions = 10) {
             pointLoads.filter(p => Math.abs(p.x - x2) < 1e-8).forEach(p => {
                 const P_ax = c * (p.Fx || 0) + s * (p.Fy || 0);
                 const P_prp = -s * (p.Fx || 0) + c * (p.Fy || 0);
-                normal -= P_ax;
+                normal += P_ax;
                 shear -= P_prp;
                 moment += (p.Mz || 0);
 


### PR DESCRIPTION
## Summary
- fix calculation of axial force diagrams for line and point member loads

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Chart/d3 not defined due to blocked CDN requests)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff007f588320b85cc783e2b5b763