### PR TITLE
Add frame save/load feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,9 @@
         <div id="frameLayout">
             <div id="frameControls">
                 <button onclick="clearFrameModel()">Clear the model</button>
+                <button id="frameSaveBtn">Save Model</button>
+                <button id="frameLoadBtn">Load Model</button>
+                <input type="file" id="frameLoadFile" style="display:none" accept="application/json">
                 <div class="section">
                     <h2>Beams</h2>
                     <div id="frameBeams"></div>
@@ -834,6 +837,44 @@ document.getElementById('maxNodeDist').onchange=function(){
 };
 document.getElementById('exportBtn').onclick=function(){
     window.print();
+};
+
+document.getElementById('frameSaveBtn').onclick=function(){
+    const data=JSON.stringify(frameState);
+    const blob=new Blob([data],{type:'application/json'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a');
+    a.href=url; a.download='frame_model.json';
+    a.click();
+    URL.revokeObjectURL(url);
+};
+document.getElementById('frameLoadBtn').onclick=function(){
+    document.getElementById('frameLoadFile').click();
+};
+document.getElementById('frameLoadFile').onchange=function(){
+    const file=this.files[0];
+    if(!file) return;
+    const reader=new FileReader();
+    reader.onload=e=>{
+        try{
+            const obj=JSON.parse(e.target.result);
+            frameState.beams=obj.beams||[];
+            frameState.supports=obj.supports||[];
+            frameState.loads=obj.loads||[];
+            frameState.memberPointLoads=obj.memberPointLoads||[];
+            frameState.memberLineLoads=obj.memberLineLoads||[];
+            rebuildNodes();
+            rebuildFrameBeams();
+            rebuildFrameSupports();
+            rebuildFrameLoads();
+            rebuildFrameMemberPointLoads();
+            rebuildFrameMemberLineLoads();
+            solveFrame();
+        }catch(err){
+            alert('Invalid file');
+        }
+    };
+    reader.readAsText(file);
 };
 
 // FEM Solver
@@ -1788,7 +1829,14 @@ function solveFrame(){
         if(alphaEl){alphaEl.style.display='none';alphaEl.innerHTML='';}
     }
     const res=analysis==='pdelta'?computeFrameResultsPDelta_Kg(frame):computeFrameResults(frame);
-    if(!res) return;
+    if(!res){
+        frameRes=null;
+        frameDiags=[];
+        drawFrame(null,[]);
+        updateFrameReactions(null);
+        updateFrameWarning();
+        return;
+    }
     updateFrameReactions(res);
     updateFrameWarning();
     const div=parseInt(document.getElementById('frameDiv')?.value||'1');

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,5 +5,7 @@ const html = fs.readFileSync('index.html', 'utf8');
 
 assert(/id=["']addSpanBtn["']/.test(html), 'Add Span button not found');
 assert(/id=["']exportBtn["']/.test(html), 'Export button not found');
+assert(/id=["']frameSaveBtn["']/.test(html), 'Frame Save button not found');
+assert(/id=["']frameLoadBtn["']/.test(html), 'Frame Load button not found');
 
 console.log('Integration tests passed');


### PR DESCRIPTION
## Summary
- add Save and Load buttons to Frame tab
- implement client-side JSON export/import for frame models
- clear diagrams when model is cleared
- update integration tests for new buttons

## Testing
- `npm ci` *(fails: package-lock.json missing)*
- `npm install`
- `npm test`
- `npm run lint`
- `npm run lint:strict`
- `npm run test:integration`
- `npm run test:smoke` *(fails: Chart and d3 undefined due to blocked CDN requests)*

------
https://chatgpt.com/codex/tasks/task_e_687cbcb224a0832089d71bc1bdcaa473