### PR TITLE
Fix cross-section refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,6 +456,7 @@ function setMaterial(mat){
         updateSectionProps(first);
         updateDesignProps(first);
         updateSelfWeightLineLoad();
+        solveSelected();
     }
 }
 


### PR DESCRIPTION
## Summary
- recalc beam analysis results whenever material selection resets cross-section

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Chart/d3 not defined due to blocked CDN)*

------
https://chatgpt.com/codex/tasks/task_e_6881e13d52788320837900a83b971fcc