### PR TITLE
Fix frame section dropdown and concrete shear

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,6 +476,7 @@ function setMaterial(mat){
         updateSelfWeightLineLoad();
         solveSelected();
     }
+    rebuildFrameBeams();
 }
 
 function loadCrossSections(){
@@ -494,6 +495,7 @@ function loadCrossSections(){
     Promise.all(promises).then(()=>{
         allSections = Object.assign({}, steelSections, timberSections, concreteSections);
         setMaterial(state.material || 'steel');
+        rebuildFrameBeams();
     });
 }
 loadCrossSections();
@@ -942,6 +944,9 @@ document.getElementById('rightSupportToggle').onchange=function(){
     solveSelected();
 };
 document.getElementById('designLb').onchange=function(){
+    updateDesignProps(document.getElementById('designSectionSelect').value);
+};
+document.getElementById('designRho').onchange=function(){
     updateDesignProps(document.getElementById('designSectionSelect').value);
 };
 
@@ -1589,7 +1594,7 @@ function updateDesignEquations(design){
                      String.raw`$$V_{Rd}=\frac{A_v f_{v,k}}{\gamma_M}=${disp(vRd)}\,\mathrm{kN}$$`;
     } else if(design.material==='concrete'){
         div.innerHTML=String.raw`$$M_{Rd}=A_s f_{yd}(d-0.5x)=${disp(mRd)}\,\mathrm{kN\,m}$$<br>`+
-                     String.raw`$$V_{Rd}=0.5 b d f_{cd}=${disp(vRd)}\,\mathrm{kN}$$`;
+                     String.raw`$$V_{Rd}=\frac{A_{sw}}{s} f_{yd} d=${disp(vRd)}\,\mathrm{kN}$$`;
     } else {
         const iw=design.Iw!==undefined?design.Iw.toExponential(2):'-';
         const it=design.It!==undefined?design.It.toExponential(2):'-';

--- a/solver.js
+++ b/solver.js
@@ -336,8 +336,9 @@ function computeSectionDesign(name, opts){
         const x = Math.min(As*fyd/(0.85*fcd*b), 0.45*hsec);
         const z = d - 0.5*x;
         const MRd = As*fyd*z;
-        const VRd = 0.5*fcd*b*d;
-        return {EI, MRd, MRdLBA: MRd, VRd, W, gamma: gammaC, material: 'concrete', x, d};
+        const Asw_s = opts.Asw_s !== undefined ? opts.Asw_s : 5e-4; // m^2/m (e.g. two 8mm legs @200mm)
+        const VRd = Asw_s * fyd * d;
+        return {EI, MRd, MRdLBA: MRd, VRd, W, gamma: gammaC, material: 'concrete', x, d, Asw_s};
     }
 
     const E = opts.E !== undefined ? opts.E : 210e9;


### PR DESCRIPTION
## Summary
- refresh frame beam section selects when material data loads
- display shear design equation for stirrups and update automatically when rho changes
- compute concrete VRd based on stirrups instead of concrete only

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68864fa0731883208c4275cc53476610