### PR TITLE
Color frame beams by material

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,6 +497,9 @@ function loadCrossSections(){
     }
     promises.push(fetch('./concrete_cross_sections.json').then(r=>r.json()).then(d=>{concreteSections={};d.forEach(cs=>{concreteSections[cs.profile]=cs;});}));
     Promise.all(promises).then(()=>{
+        Object.values(steelSections).forEach(cs=>cs.material='steel');
+        Object.values(timberSections).forEach(cs=>cs.material='timber');
+        Object.values(concreteSections).forEach(cs=>cs.material='concrete');
         allSections = Object.assign({}, steelSections, timberSections, concreteSections);
         setMaterial(state.material || 'steel');
         rebuildFrameBeams();
@@ -2163,14 +2166,21 @@ function drawFrame(res,diags){
         const perp=dir.rotate(90);
         const h=(allSections[b.section]?.h_mm||0)/1000;
         const half=h*scale/2;
-        const path=new framePaper.Path({strokeColor:'gray', fillColor:'#eee'});
+        const material = allSections[b.section]?.material;
+        const colors = {
+            concrete: {stroke: '#808080', fill: '#d3d3d3'},
+            steel: {stroke: '#7df9ff', fill: 'rgba(125,249,255,0.3)'},
+            timber: {stroke: '#8B4513', fill: '#DEB887'}
+        };
+        const c = colors[material] || {stroke: 'gray', fill: '#eee'};
+        const path=new framePaper.Path({strokeColor:c.stroke, fillColor:c.fill});
         path.add(p1.add(perp.multiply(-half)));
         path.add(p1.add(perp.multiply(half)));
         path.add(p2.add(perp.multiply(half)));
         path.add(p2.add(perp.multiply(-half)));
         path.closed=true;
         const mid=p1.add(p2).divide(2);
-        new framePaper.PointText({point:mid.add([0,-10]), content:b.name || `B${i+1}`, fillColor:'green', fontSize:12});
+        new framePaper.PointText({point:mid.add([0,-10]), content:b.name || `B${i+1}`, fillColor:c.stroke, fontSize:12});
         const arrowEnd=p1.add(p2.subtract(p1).multiply(0.8));
         new framePaper.Path({segments:[p1,arrowEnd], strokeColor:'black', dashArray:[4,4]});
         const aDir=arrowEnd.subtract(p1).normalize();


### PR DESCRIPTION
## Summary
- Color frame beams using material-specific palettes
- Annotate section data with material types for easy lookup

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json)*
- `npm install`
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: Error: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688ba0a0be988320bd36609944bd8e30