### PR TITLE
Add deprecation banner linking to new app

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
     </style>
 </head>
 <body>
+    <div id="deprecatedBanner" style="background:#ffdddd;border:1px solid #ffb3b3;padding:10px;margin:0 10px 10px 10px;text-align:center;font-weight:bold;color:#b22222;">
+        This app is no longer maintained. The new version is available here:
+        <a href="https://thunderstruct.vercel.app">https://thunderstruct.vercel.app</a>
+    </div>
     <div id="header">
         <img src="9326693B-D49A-434B-A844-C1D583FF027B.png" alt="ThunderStruct logo">
         <h1>ThunderStruct</h1>


### PR DESCRIPTION
## Summary
- Display a prominent notice that the app is no longer maintained and provide a link to the new version at thunderstruct.vercel.app

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm install`
- `npm test`
- `npm run lint`
- `npm run test:integration`
- `npm run lint:strict`
- `npm run test:smoke` *(fails: console errors such as failed resource loading and CORS issues)*


------
https://chatgpt.com/codex/tasks/task_e_68c5782b9af08320aad4514d2c282fe7